### PR TITLE
Add theater domain model #1374

### DIFF
--- a/src/main/java/es/upm/miw/apaw/domain/models/theater/TheaterArtist.java
+++ b/src/main/java/es/upm/miw/apaw/domain/models/theater/TheaterArtist.java
@@ -1,0 +1,33 @@
+package es.upm.miw.apaw.domain.models.theater;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Set;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TheaterArtist {
+    @NotNull
+    @NotBlank
+    private String artistCode;
+    @NotNull
+    @NotBlank
+    private String artistFullName;
+    @NotNull
+    private LocalDate artistBirthDate;
+    @NotNull
+    private BigDecimal artistFee;
+    @NotNull
+    private Boolean artistActive;
+    @NotNull
+    private Set<TheaterPerformance> artistPerformances;
+}

--- a/src/main/java/es/upm/miw/apaw/domain/models/theater/TheaterHall.java
+++ b/src/main/java/es/upm/miw/apaw/domain/models/theater/TheaterHall.java
@@ -1,0 +1,31 @@
+package es.upm.miw.apaw.domain.models.theater;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TheaterHall {
+    @NotNull
+    @NotBlank
+    private String hallCode;
+    @NotNull
+    @NotBlank
+    private String hallName;
+    @NotNull
+    private Integer hallCapacity;
+    @NotNull
+    private Boolean hallAccessible;
+    @NotNull
+    private TheaterVenue hallVenue;
+    @NotNull
+    private List<TheaterPerformance> hallPerformances;
+}

--- a/src/main/java/es/upm/miw/apaw/domain/models/theater/TheaterPerformance.java
+++ b/src/main/java/es/upm/miw/apaw/domain/models/theater/TheaterPerformance.java
@@ -1,0 +1,35 @@
+package es.upm.miw.apaw.domain.models.theater;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Set;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TheaterPerformance {
+    @NotNull
+    @NotBlank
+    private String performanceCode;
+    @NotNull
+    @NotBlank
+    private String performanceTitle;
+    @NotNull
+    private LocalDate performanceDate;
+    @NotNull
+    private Integer performanceDurationMinutes;
+    @NotNull
+    private BigDecimal performanceTicketPrice;
+    @NotNull
+    private TheaterHall performanceHall;
+    @NotNull
+    private Set<TheaterArtist> performanceArtists;
+}

--- a/src/main/java/es/upm/miw/apaw/domain/models/theater/TheaterVenue.java
+++ b/src/main/java/es/upm/miw/apaw/domain/models/theater/TheaterVenue.java
@@ -1,0 +1,36 @@
+package es.upm.miw.apaw.domain.models.theater;
+
+import es.upm.miw.apaw.domain.models.UserDto;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TheaterVenue {
+    @NotNull
+    @NotBlank
+    private String venueCode;
+    @NotNull
+    @NotBlank
+    private String venueName;
+    @NotNull
+    @NotBlank
+    private String venueCity;
+    @NotNull
+    private Boolean venueOpen;
+    @NotNull
+    private LocalDateTime venueCreatedAt;
+    @NotNull
+    private List<TheaterHall> venueHalls;
+    @NotNull
+    private UserDto venueManager;
+}


### PR DESCRIPTION
## Summary

This PR implements the domain model for the story:theater practice.

Related to #1374.

## Changes

- Added TheaterVenue
- Added TheaterHall
- Added TheaterPerformance
- Added TheaterArtist

## Assignment requirements covered

- 4 business documents.
- At least 3 attributes per document.
- 19 business attributes in total.
- Includes LocalDateTime, LocalDate, Boolean, Integer, and BigDecimal.
- Money fields use BigDecimal.
- Required relationships are represented:
  - 1..n
  - 
..1
  - 
..n
- Package name is 	heater, matching story:theater.

## Verification

- mvn -q -DskipTests compile passes.