### PR TITLE
Fix theater model unidirectional relationships #1374

### DIFF
--- a/src/main/java/es/upm/miw/apaw/domain/models/theater/TheaterArtist.java
+++ b/src/main/java/es/upm/miw/apaw/domain/models/theater/TheaterArtist.java
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.Set;
 
 @Builder
 @Data
@@ -28,6 +27,4 @@ public class TheaterArtist {
     private BigDecimal artistFee;
     @NotNull
     private Boolean artistActive;
-    @NotNull
-    private Set<TheaterPerformance> artistPerformances;
 }

--- a/src/main/java/es/upm/miw/apaw/domain/models/theater/TheaterHall.java
+++ b/src/main/java/es/upm/miw/apaw/domain/models/theater/TheaterHall.java
@@ -7,8 +7,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
-
 @Builder
 @Data
 @NoArgsConstructor
@@ -24,8 +22,4 @@ public class TheaterHall {
     private Integer hallCapacity;
     @NotNull
     private Boolean hallAccessible;
-    @NotNull
-    private TheaterVenue hallVenue;
-    @NotNull
-    private List<TheaterPerformance> hallPerformances;
 }


### PR DESCRIPTION
Related to #1374.

This PR fixes the Theater domain model after the teacher review.

Changes:
- Removes reverse relationship fields from TheaterHall.
- Removes reverse relationship field from TheaterArtist.
- Keeps the required unidirectional relationships:
  - TheaterVenue -> TheaterHall
  - TheaterVenue -> UserDto
  - TheaterPerformance -> TheaterHall
  - TheaterPerformance -> TheaterArtist

Validation:
- mvn -q -DskipTests compile
- mvn -q test

The issue must remain open until the teacher confirms that the updated model is correct.