### PR TITLE
Add theater persistence layer #1380

### DIFF
--- a/src/main/java/es/upm/miw/apaw/adapters/mongodb/DatabaseSeeder.java
+++ b/src/main/java/es/upm/miw/apaw/adapters/mongodb/DatabaseSeeder.java
@@ -10,6 +10,7 @@ import es.upm.miw.apaw.adapters.mongodb.shop.daos.ShopSeeder;
 import es.upm.miw.apaw.adapters.mongodb.studentcouncil.daos.StudentCouncilSeeder;
 import es.upm.miw.apaw.adapters.mongodb.sports.academy.daos.SportsAcademySeeder;
 import es.upm.miw.apaw.adapters.mongodb.vehicle.daos.VehicleSeeder;
+import es.upm.miw.apaw.adapters.mongodb.theater.daos.TheaterSeeder;
 import es.upm.miw.apaw.adapters.mongodb.apiary.daos.ApiarySeeder;
 import es.upm.miw.apaw.adapters.mongodb.university.daos.UniversitySeeder;
 import es.upm.miw.apaw.adapters.mongodb.recipes.daos.RecipesSeeder;
@@ -54,6 +55,7 @@ public class DatabaseSeeder {
     private final MusicSeeder musicSeeder;
     private final MartialArtsGymSeeder martialArtsGymSeeder;
     private final ClinicSeeder clinicSeeder;
+    private final TheaterSeeder theaterSeeder;
 
     @Autowired
     public DatabaseSeeder(
@@ -76,7 +78,7 @@ public class DatabaseSeeder {
             FootballSeeder footballSeeder,
             MetroSeeder metroSeeder,
             MusicSeeder musicSeeder, MartialArtsGymSeeder martialArtsGymSeeder,
-            ClinicSeeder clinicSeeder
+            ClinicSeeder clinicSeeder, TheaterSeeder theaterSeeder
     ) {
 
         this.shopSeeder = shopSeeder;
@@ -100,6 +102,7 @@ public class DatabaseSeeder {
         this.musicSeeder = musicSeeder;
         this.martialArtsGymSeeder = martialArtsGymSeeder;
         this.clinicSeeder = clinicSeeder;
+        this.theaterSeeder = theaterSeeder;
         this.seedDatabase();
 
     }
@@ -126,6 +129,7 @@ public class DatabaseSeeder {
         this.musicSeeder.seedDatabase();
         this.martialArtsGymSeeder.seedDatabase();
         this.clinicSeeder.seedDatabase();
+        this.theaterSeeder.seedDatabase();
     }
 
     public void deleteAll() {
@@ -150,6 +154,7 @@ public class DatabaseSeeder {
         this.musicSeeder.deleteAll();
         this.martialArtsGymSeeder.deleteAll();
         this.clinicSeeder.deleteAll();
+        this.theaterSeeder.deleteAll();
     }
 
     public void reSeedDatabase() {

--- a/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/daos/TheaterArtistRepository.java
+++ b/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/daos/TheaterArtistRepository.java
@@ -1,0 +1,13 @@
+package es.upm.miw.apaw.adapters.mongodb.theater.daos;
+
+import es.upm.miw.apaw.adapters.mongodb.theater.entities.TheaterArtistEntity;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface TheaterArtistRepository extends MongoRepository<TheaterArtistEntity, UUID> {
+    Optional<TheaterArtistEntity> findByArtistCode(String artistCode);
+
+    int deleteByArtistCode(String artistCode);
+}

--- a/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/daos/TheaterHallRepository.java
+++ b/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/daos/TheaterHallRepository.java
@@ -1,0 +1,13 @@
+package es.upm.miw.apaw.adapters.mongodb.theater.daos;
+
+import es.upm.miw.apaw.adapters.mongodb.theater.entities.TheaterHallEntity;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface TheaterHallRepository extends MongoRepository<TheaterHallEntity, UUID> {
+    Optional<TheaterHallEntity> findByHallCode(String hallCode);
+
+    int deleteByHallCode(String hallCode);
+}

--- a/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/daos/TheaterPerformanceRepository.java
+++ b/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/daos/TheaterPerformanceRepository.java
@@ -1,0 +1,13 @@
+package es.upm.miw.apaw.adapters.mongodb.theater.daos;
+
+import es.upm.miw.apaw.adapters.mongodb.theater.entities.TheaterPerformanceEntity;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface TheaterPerformanceRepository extends MongoRepository<TheaterPerformanceEntity, UUID> {
+    Optional<TheaterPerformanceEntity> findByPerformanceCode(String performanceCode);
+
+    int deleteByPerformanceCode(String performanceCode);
+}

--- a/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/daos/TheaterSeeder.java
+++ b/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/daos/TheaterSeeder.java
@@ -1,0 +1,170 @@
+package es.upm.miw.apaw.adapters.mongodb.theater.daos;
+
+import es.upm.miw.apaw.adapters.mongodb.theater.entities.TheaterArtistEntity;
+import es.upm.miw.apaw.adapters.mongodb.theater.entities.TheaterHallEntity;
+import es.upm.miw.apaw.adapters.mongodb.theater.entities.TheaterPerformanceEntity;
+import es.upm.miw.apaw.adapters.mongodb.theater.entities.TheaterVenueEntity;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+@Profile({"dev", "test"})
+@Log4j2
+public class TheaterSeeder {
+
+    private final TheaterArtistRepository theaterArtistRepository;
+    private final TheaterHallRepository theaterHallRepository;
+    private final TheaterVenueRepository theaterVenueRepository;
+    private final TheaterPerformanceRepository theaterPerformanceRepository;
+
+    @Autowired
+    public TheaterSeeder(
+            TheaterArtistRepository theaterArtistRepository,
+            TheaterHallRepository theaterHallRepository,
+            TheaterVenueRepository theaterVenueRepository,
+            TheaterPerformanceRepository theaterPerformanceRepository) {
+        this.theaterArtistRepository = theaterArtistRepository;
+        this.theaterHallRepository = theaterHallRepository;
+        this.theaterVenueRepository = theaterVenueRepository;
+        this.theaterPerformanceRepository = theaterPerformanceRepository;
+    }
+
+    public void seedDatabase() {
+        log.warn("------- Theater Initial Load -----------");
+
+        if (theaterArtistRepository.count() > 0) {
+            log.warn("------- Theater already seeded -----------");
+            return;
+        }
+
+        TheaterArtistEntity[] artists = {
+                TheaterArtistEntity.builder()
+                        .id(UUID.fromString("bbbbbbbb-cccc-dddd-eeee-ffff00000001"))
+                        .artistCode("ART001")
+                        .artistFullName("Maria Garcia")
+                        .artistBirthDate(LocalDate.of(1990, 3, 15))
+                        .artistFee(new BigDecimal("1500.00"))
+                        .artistActive(true)
+                        .build(),
+                TheaterArtistEntity.builder()
+                        .id(UUID.fromString("bbbbbbbb-cccc-dddd-eeee-ffff00000002"))
+                        .artistCode("ART002")
+                        .artistFullName("John Smith")
+                        .artistBirthDate(LocalDate.of(1985, 7, 22))
+                        .artistFee(new BigDecimal("1200.00"))
+                        .artistActive(true)
+                        .build(),
+                TheaterArtistEntity.builder()
+                        .id(UUID.fromString("bbbbbbbb-cccc-dddd-eeee-ffff00000003"))
+                        .artistCode("ART003")
+                        .artistFullName("Ana Lopez")
+                        .artistBirthDate(LocalDate.of(1995, 11, 8))
+                        .artistFee(new BigDecimal("1000.00"))
+                        .artistActive(false)
+                        .build()
+        };
+        theaterArtistRepository.saveAll(Arrays.asList(artists));
+
+        TheaterHallEntity[] halls = {
+                TheaterHallEntity.builder()
+                        .id(UUID.fromString("bbbbbbbb-cccc-dddd-eeee-ffff00000011"))
+                        .hallCode("HAL001")
+                        .hallName("Main Stage")
+                        .hallCapacity(500)
+                        .hallAccessible(true)
+                        .build(),
+                TheaterHallEntity.builder()
+                        .id(UUID.fromString("bbbbbbbb-cccc-dddd-eeee-ffff00000012"))
+                        .hallCode("HAL002")
+                        .hallName("Studio Theater")
+                        .hallCapacity(150)
+                        .hallAccessible(true)
+                        .build(),
+                TheaterHallEntity.builder()
+                        .id(UUID.fromString("bbbbbbbb-cccc-dddd-eeee-ffff00000013"))
+                        .hallCode("HAL003")
+                        .hallName("Black Box")
+                        .hallCapacity(80)
+                        .hallAccessible(false)
+                        .build()
+        };
+        theaterHallRepository.saveAll(Arrays.asList(halls));
+
+        TheaterVenueEntity[] venues = {
+                TheaterVenueEntity.builder()
+                        .id(UUID.fromString("bbbbbbbb-cccc-dddd-eeee-ffff00000021"))
+                        .venueCode("VEN001")
+                        .venueName("Gran Teatro")
+                        .venueCity("Madrid")
+                        .venueOpen(true)
+                        .venueCreatedAt(LocalDateTime.of(2020, 1, 10, 0, 0))
+                        .venueHalls(List.of(halls[0], halls[1]))
+                        .venueManagerId(UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeffff0001"))
+                        .build(),
+                TheaterVenueEntity.builder()
+                        .id(UUID.fromString("bbbbbbbb-cccc-dddd-eeee-ffff00000022"))
+                        .venueCode("VEN002")
+                        .venueName("Teatro Cultural")
+                        .venueCity("Barcelona")
+                        .venueOpen(true)
+                        .venueCreatedAt(LocalDateTime.of(2021, 6, 20, 0, 0))
+                        .venueHalls(List.of(halls[2]))
+                        .venueManagerId(UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeffff0002"))
+                        .build()
+        };
+        theaterVenueRepository.saveAll(Arrays.asList(venues));
+
+        TheaterPerformanceEntity[] performances = {
+                TheaterPerformanceEntity.builder()
+                        .id(UUID.fromString("bbbbbbbb-cccc-dddd-eeee-ffff00000031"))
+                        .performanceCode("PER001")
+                        .performanceTitle("Romeo and Juliet")
+                        .performanceDate(LocalDate.of(2026, 9, 15))
+                        .performanceDurationMinutes(120)
+                        .performanceTicketPrice(new BigDecimal("45.00"))
+                        .performanceHall(halls[0])
+                        .performanceArtists(new HashSet<>(List.of(artists[0], artists[1])))
+                        .build(),
+                TheaterPerformanceEntity.builder()
+                        .id(UUID.fromString("bbbbbbbb-cccc-dddd-eeee-ffff00000032"))
+                        .performanceCode("PER002")
+                        .performanceTitle("The Magic Flute")
+                        .performanceDate(LocalDate.of(2026, 10, 5))
+                        .performanceDurationMinutes(150)
+                        .performanceTicketPrice(new BigDecimal("55.00"))
+                        .performanceHall(halls[0])
+                        .performanceArtists(new HashSet<>(List.of(artists[1])))
+                        .build(),
+                TheaterPerformanceEntity.builder()
+                        .id(UUID.fromString("bbbbbbbb-cccc-dddd-eeee-ffff00000033"))
+                        .performanceCode("PER003")
+                        .performanceTitle("Contemporary Dance Night")
+                        .performanceDate(LocalDate.of(2026, 11, 1))
+                        .performanceDurationMinutes(90)
+                        .performanceTicketPrice(new BigDecimal("30.00"))
+                        .performanceHall(halls[2])
+                        .performanceArtists(new HashSet<>(List.of(artists[0], artists[2])))
+                        .build()
+        };
+        theaterPerformanceRepository.saveAll(Arrays.asList(performances));
+
+        log.warn("------- Theater seeding completed -----------");
+    }
+
+    public void deleteAll() {
+        theaterPerformanceRepository.deleteAll();
+        theaterVenueRepository.deleteAll();
+        theaterHallRepository.deleteAll();
+        theaterArtistRepository.deleteAll();
+    }
+}

--- a/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/daos/TheaterVenueRepository.java
+++ b/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/daos/TheaterVenueRepository.java
@@ -1,0 +1,13 @@
+package es.upm.miw.apaw.adapters.mongodb.theater.daos;
+
+import es.upm.miw.apaw.adapters.mongodb.theater.entities.TheaterVenueEntity;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface TheaterVenueRepository extends MongoRepository<TheaterVenueEntity, UUID> {
+    Optional<TheaterVenueEntity> findByVenueCode(String venueCode);
+
+    int deleteByVenueCode(String venueCode);
+}

--- a/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/entities/TheaterArtistEntity.java
+++ b/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/entities/TheaterArtistEntity.java
@@ -1,0 +1,47 @@
+package es.upm.miw.apaw.adapters.mongodb.theater.entities;
+
+import es.upm.miw.apaw.domain.models.theater.TheaterArtist;
+import lombok.*;
+import org.springframework.beans.BeanUtils;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@Document(collection = "theater_artists")
+public class TheaterArtistEntity {
+    @Id
+    private UUID id;
+
+    @EqualsAndHashCode.Include
+    @Indexed(unique = true)
+    private String artistCode;
+
+    private String artistFullName;
+    private LocalDate artistBirthDate;
+    private BigDecimal artistFee;
+    private Boolean artistActive;
+
+    public TheaterArtistEntity(TheaterArtist theaterArtist) {
+        BeanUtils.copyProperties(theaterArtist, this);
+        this.id = UUID.randomUUID();
+    }
+
+    public void fromTheaterArtist(TheaterArtist theaterArtist) {
+        BeanUtils.copyProperties(theaterArtist, this);
+    }
+
+    public TheaterArtist toTheaterArtist() {
+        TheaterArtist theaterArtist = new TheaterArtist();
+        BeanUtils.copyProperties(this, theaterArtist);
+        return theaterArtist;
+    }
+}

--- a/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/entities/TheaterHallEntity.java
+++ b/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/entities/TheaterHallEntity.java
@@ -1,0 +1,44 @@
+package es.upm.miw.apaw.adapters.mongodb.theater.entities;
+
+import es.upm.miw.apaw.domain.models.theater.TheaterHall;
+import lombok.*;
+import org.springframework.beans.BeanUtils;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.UUID;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@Document(collection = "theater_halls")
+public class TheaterHallEntity {
+    @Id
+    private UUID id;
+
+    @EqualsAndHashCode.Include
+    @Indexed(unique = true)
+    private String hallCode;
+
+    private String hallName;
+    private Integer hallCapacity;
+    private Boolean hallAccessible;
+
+    public TheaterHallEntity(TheaterHall theaterHall) {
+        BeanUtils.copyProperties(theaterHall, this);
+        this.id = UUID.randomUUID();
+    }
+
+    public void fromTheaterHall(TheaterHall theaterHall) {
+        BeanUtils.copyProperties(theaterHall, this);
+    }
+
+    public TheaterHall toTheaterHall() {
+        TheaterHall theaterHall = new TheaterHall();
+        BeanUtils.copyProperties(this, theaterHall);
+        return theaterHall;
+    }
+}

--- a/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/entities/TheaterPerformanceEntity.java
+++ b/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/entities/TheaterPerformanceEntity.java
@@ -1,0 +1,66 @@
+package es.upm.miw.apaw.adapters.mongodb.theater.entities;
+
+import es.upm.miw.apaw.domain.models.theater.TheaterArtist;
+import es.upm.miw.apaw.domain.models.theater.TheaterHall;
+import es.upm.miw.apaw.domain.models.theater.TheaterPerformance;
+import lombok.*;
+import org.springframework.beans.BeanUtils;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.DBRef;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@Document(collection = "theater_performances")
+public class TheaterPerformanceEntity {
+    @Id
+    private UUID id;
+
+    @EqualsAndHashCode.Include
+    @Indexed(unique = true)
+    private String performanceCode;
+
+    private String performanceTitle;
+    private LocalDate performanceDate;
+    private Integer performanceDurationMinutes;
+    private BigDecimal performanceTicketPrice;
+
+    @DBRef
+    private TheaterHallEntity performanceHall;
+
+    @DBRef
+    private Set<TheaterArtistEntity> performanceArtists;
+
+    public TheaterPerformanceEntity(TheaterPerformance theaterPerformance) {
+        BeanUtils.copyProperties(theaterPerformance, this, "performanceHall", "performanceArtists");
+        this.id = UUID.randomUUID();
+    }
+
+    public void fromTheaterPerformance(TheaterPerformance theaterPerformance) {
+        BeanUtils.copyProperties(theaterPerformance, this, "performanceHall", "performanceArtists");
+    }
+
+    public TheaterPerformance toTheaterPerformance() {
+        TheaterPerformance theaterPerformance = new TheaterPerformance();
+        BeanUtils.copyProperties(this, theaterPerformance, "performanceHall", "performanceArtists");
+        if (this.performanceHall != null) {
+            theaterPerformance.setPerformanceHall(this.performanceHall.toTheaterHall());
+        }
+        if (this.performanceArtists != null) {
+            theaterPerformance.setPerformanceArtists(this.performanceArtists.stream()
+                    .map(TheaterArtistEntity::toTheaterArtist)
+                    .collect(Collectors.toSet()));
+        }
+        return theaterPerformance;
+    }
+}

--- a/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/entities/TheaterVenueEntity.java
+++ b/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/entities/TheaterVenueEntity.java
@@ -1,0 +1,71 @@
+package es.upm.miw.apaw.adapters.mongodb.theater.entities;
+
+import es.upm.miw.apaw.domain.models.theater.TheaterHall;
+import es.upm.miw.apaw.domain.models.theater.TheaterVenue;
+import es.upm.miw.apaw.domain.models.theater.TheaterPerformance;
+import lombok.*;
+import org.springframework.beans.BeanUtils;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.DBRef;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@Document(collection = "theater_venues")
+public class TheaterVenueEntity {
+    @Id
+    private UUID id;
+
+    @EqualsAndHashCode.Include
+    @Indexed(unique = true)
+    private String venueCode;
+
+    private String venueName;
+    private String venueCity;
+    private Boolean venueOpen;
+    private LocalDateTime venueCreatedAt;
+
+    @DBRef
+    private List<TheaterHallEntity> venueHalls;
+
+    private UUID venueManagerId;
+
+    public TheaterVenueEntity(TheaterVenue theaterVenue) {
+        BeanUtils.copyProperties(theaterVenue, this, "venueHalls", "venueManager");
+        this.id = UUID.randomUUID();
+        if (theaterVenue.getVenueManager() != null) {
+            this.venueManagerId = theaterVenue.getVenueManager().getId();
+        }
+    }
+
+    public void fromTheaterVenue(TheaterVenue theaterVenue) {
+        BeanUtils.copyProperties(theaterVenue, this, "venueHalls", "venueManager");
+        if (theaterVenue.getVenueManager() != null) {
+            this.venueManagerId = theaterVenue.getVenueManager().getId();
+        }
+    }
+
+    public TheaterVenue toTheaterVenue() {
+        TheaterVenue theaterVenue = new TheaterVenue();
+        BeanUtils.copyProperties(this, theaterVenue, "venueHalls");
+        if (this.venueManagerId != null) {
+            theaterVenue.setVenueManager(
+                    es.upm.miw.apaw.domain.models.UserDto.builder().id(venueManagerId).build()
+            );
+        }
+        if (this.venueHalls != null) {
+            theaterVenue.setVenueHalls(this.venueHalls.stream()
+                    .map(TheaterHallEntity::toTheaterHall)
+                    .toList());
+        }
+        return theaterVenue;
+    }
+}

--- a/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterArtistPersistenceMongodb.java
+++ b/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterArtistPersistenceMongodb.java
@@ -1,0 +1,53 @@
+package es.upm.miw.apaw.adapters.mongodb.theater.persistence;
+
+import es.upm.miw.apaw.adapters.mongodb.theater.daos.TheaterArtistRepository;
+import es.upm.miw.apaw.adapters.mongodb.theater.entities.TheaterArtistEntity;
+import es.upm.miw.apaw.domain.exceptions.NotFoundException;
+import es.upm.miw.apaw.domain.models.theater.TheaterArtist;
+import es.upm.miw.apaw.domain.persistenceports.theater.TheaterArtistPersistence;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import java.util.stream.Stream;
+
+@Repository("theaterArtistPersistence")
+public class TheaterArtistPersistenceMongodb implements TheaterArtistPersistence {
+
+    private final TheaterArtistRepository theaterArtistRepository;
+
+    @Autowired
+    public TheaterArtistPersistenceMongodb(TheaterArtistRepository theaterArtistRepository) {
+        this.theaterArtistRepository = theaterArtistRepository;
+    }
+
+    @Override
+    public TheaterArtist create(TheaterArtist theaterArtist) {
+        return this.theaterArtistRepository.save(new TheaterArtistEntity(theaterArtist)).toTheaterArtist();
+    }
+
+    @Override
+    public TheaterArtist read(String artistCode) {
+        return this.theaterArtistRepository.findByArtistCode(artistCode)
+                .orElseThrow(() -> new NotFoundException("TheaterArtist artistCode: " + artistCode))
+                .toTheaterArtist();
+    }
+
+    @Override
+    public TheaterArtist update(String artistCode, TheaterArtist theaterArtist) {
+        TheaterArtistEntity entity = this.theaterArtistRepository.findByArtistCode(artistCode)
+                .orElseThrow(() -> new NotFoundException("TheaterArtist artistCode: " + artistCode));
+        entity.fromTheaterArtist(theaterArtist);
+        return this.theaterArtistRepository.save(entity).toTheaterArtist();
+    }
+
+    @Override
+    public Stream<TheaterArtist> readAll() {
+        return this.theaterArtistRepository.findAll().stream()
+                .map(TheaterArtistEntity::toTheaterArtist);
+    }
+
+    @Override
+    public boolean existsByArtistCode(String artistCode) {
+        return this.theaterArtistRepository.findByArtistCode(artistCode).isPresent();
+    }
+}

--- a/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterHallPersistenceMongodb.java
+++ b/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterHallPersistenceMongodb.java
@@ -1,0 +1,53 @@
+package es.upm.miw.apaw.adapters.mongodb.theater.persistence;
+
+import es.upm.miw.apaw.adapters.mongodb.theater.daos.TheaterHallRepository;
+import es.upm.miw.apaw.adapters.mongodb.theater.entities.TheaterHallEntity;
+import es.upm.miw.apaw.domain.exceptions.NotFoundException;
+import es.upm.miw.apaw.domain.models.theater.TheaterHall;
+import es.upm.miw.apaw.domain.persistenceports.theater.TheaterHallPersistence;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import java.util.stream.Stream;
+
+@Repository("theaterHallPersistence")
+public class TheaterHallPersistenceMongodb implements TheaterHallPersistence {
+
+    private final TheaterHallRepository theaterHallRepository;
+
+    @Autowired
+    public TheaterHallPersistenceMongodb(TheaterHallRepository theaterHallRepository) {
+        this.theaterHallRepository = theaterHallRepository;
+    }
+
+    @Override
+    public TheaterHall create(TheaterHall theaterHall) {
+        return this.theaterHallRepository.save(new TheaterHallEntity(theaterHall)).toTheaterHall();
+    }
+
+    @Override
+    public TheaterHall read(String hallCode) {
+        return this.theaterHallRepository.findByHallCode(hallCode)
+                .orElseThrow(() -> new NotFoundException("TheaterHall hallCode: " + hallCode))
+                .toTheaterHall();
+    }
+
+    @Override
+    public TheaterHall update(String hallCode, TheaterHall theaterHall) {
+        TheaterHallEntity entity = this.theaterHallRepository.findByHallCode(hallCode)
+                .orElseThrow(() -> new NotFoundException("TheaterHall hallCode: " + hallCode));
+        entity.fromTheaterHall(theaterHall);
+        return this.theaterHallRepository.save(entity).toTheaterHall();
+    }
+
+    @Override
+    public Stream<TheaterHall> readAll() {
+        return this.theaterHallRepository.findAll().stream()
+                .map(TheaterHallEntity::toTheaterHall);
+    }
+
+    @Override
+    public boolean existsByHallCode(String hallCode) {
+        return this.theaterHallRepository.findByHallCode(hallCode).isPresent();
+    }
+}

--- a/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterPerformancePersistenceMongodb.java
+++ b/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterPerformancePersistenceMongodb.java
@@ -1,0 +1,113 @@
+package es.upm.miw.apaw.adapters.mongodb.theater.persistence;
+
+import es.upm.miw.apaw.adapters.mongodb.theater.daos.TheaterArtistRepository;
+import es.upm.miw.apaw.adapters.mongodb.theater.daos.TheaterHallRepository;
+import es.upm.miw.apaw.adapters.mongodb.theater.daos.TheaterPerformanceRepository;
+import es.upm.miw.apaw.adapters.mongodb.theater.entities.TheaterArtistEntity;
+import es.upm.miw.apaw.adapters.mongodb.theater.entities.TheaterHallEntity;
+import es.upm.miw.apaw.adapters.mongodb.theater.entities.TheaterPerformanceEntity;
+import es.upm.miw.apaw.domain.exceptions.NotFoundException;
+import es.upm.miw.apaw.domain.models.theater.TheaterArtist;
+import es.upm.miw.apaw.domain.models.theater.TheaterHall;
+import es.upm.miw.apaw.domain.models.theater.TheaterPerformance;
+import es.upm.miw.apaw.domain.persistenceports.theater.TheaterPerformancePersistence;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Repository("theaterPerformancePersistence")
+public class TheaterPerformancePersistenceMongodb implements TheaterPerformancePersistence {
+
+    private final TheaterPerformanceRepository theaterPerformanceRepository;
+    private final TheaterHallRepository theaterHallRepository;
+    private final TheaterArtistRepository theaterArtistRepository;
+
+    @Autowired
+    public TheaterPerformancePersistenceMongodb(
+            TheaterPerformanceRepository theaterPerformanceRepository,
+            TheaterHallRepository theaterHallRepository,
+            TheaterArtistRepository theaterArtistRepository) {
+        this.theaterPerformanceRepository = theaterPerformanceRepository;
+        this.theaterHallRepository = theaterHallRepository;
+        this.theaterArtistRepository = theaterArtistRepository;
+    }
+
+    @Override
+    public TheaterPerformance create(TheaterPerformance theaterPerformance) {
+        TheaterPerformanceEntity entity = new TheaterPerformanceEntity(theaterPerformance);
+        entity.setPerformanceHall(toTheaterHallEntity(theaterPerformance.getPerformanceHall()));
+        entity.setPerformanceArtists(toTheaterArtistEntitySet(theaterPerformance.getPerformanceArtists()));
+        return this.theaterPerformanceRepository.save(entity).toTheaterPerformance();
+    }
+
+    @Override
+    public TheaterPerformance read(String performanceCode) {
+        return this.theaterPerformanceRepository.findByPerformanceCode(performanceCode)
+                .orElseThrow(() -> new NotFoundException("TheaterPerformance performanceCode: " + performanceCode))
+                .toTheaterPerformance();
+    }
+
+    @Override
+    public TheaterPerformance update(String performanceCode, TheaterPerformance theaterPerformance) {
+        TheaterPerformanceEntity entity = this.theaterPerformanceRepository.findByPerformanceCode(performanceCode)
+                .orElseThrow(() -> new NotFoundException("TheaterPerformance performanceCode: " + performanceCode));
+        entity.fromTheaterPerformance(theaterPerformance);
+        entity.setPerformanceHall(toTheaterHallEntity(theaterPerformance.getPerformanceHall()));
+        entity.setPerformanceArtists(toTheaterArtistEntitySet(theaterPerformance.getPerformanceArtists()));
+        return this.theaterPerformanceRepository.save(entity).toTheaterPerformance();
+    }
+
+    private TheaterHallEntity toTheaterHallEntity(TheaterHall hall) {
+        if (hall == null) {
+            return null;
+        }
+        Optional<TheaterHallEntity> existing = theaterHallRepository.findByHallCode(hall.getHallCode());
+        if (existing.isPresent()) {
+            return existing.get();
+        }
+        TheaterHallEntity entity = new TheaterHallEntity();
+        entity.fromTheaterHall(hall);
+        return theaterHallRepository.save(entity);
+    }
+
+    private Set<TheaterArtistEntity> toTheaterArtistEntitySet(Set<TheaterArtist> artists) {
+        if (artists == null || artists.isEmpty()) {
+            return Set.of();
+        }
+        return artists.stream()
+                .map(artist -> {
+                    Optional<TheaterArtistEntity> existing = theaterArtistRepository.findByArtistCode(artist.getArtistCode());
+                    if (existing.isPresent()) {
+                        return existing.get();
+                    }
+                    TheaterArtistEntity entity = new TheaterArtistEntity();
+                    entity.fromTheaterArtist(artist);
+                    return theaterArtistRepository.save(entity);
+                })
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public Stream<TheaterPerformance> readAll() {
+        return this.theaterPerformanceRepository.findAll().stream()
+                .map(TheaterPerformanceEntity::toTheaterPerformance);
+    }
+
+    @Override
+    public boolean existsByPerformanceCode(String performanceCode) {
+        return this.theaterPerformanceRepository.findByPerformanceCode(performanceCode).isPresent();
+    }
+
+    @Override
+    public Stream<TheaterArtist> findArtistsByPerformanceCode(String performanceCode) {
+        return this.theaterPerformanceRepository.findByPerformanceCode(performanceCode)
+                .orElseThrow(() -> new NotFoundException("TheaterPerformance performanceCode: " + performanceCode))
+                .getPerformanceArtists()
+                .stream()
+                .map(TheaterArtistEntity::toTheaterArtist);
+    }
+}

--- a/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterVenuePersistenceMongodb.java
+++ b/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterVenuePersistenceMongodb.java
@@ -1,0 +1,92 @@
+package es.upm.miw.apaw.adapters.mongodb.theater.persistence;
+
+import es.upm.miw.apaw.adapters.mongodb.theater.daos.TheaterHallRepository;
+import es.upm.miw.apaw.adapters.mongodb.theater.daos.TheaterVenueRepository;
+import es.upm.miw.apaw.adapters.mongodb.theater.entities.TheaterHallEntity;
+import es.upm.miw.apaw.adapters.mongodb.theater.entities.TheaterVenueEntity;
+import es.upm.miw.apaw.domain.exceptions.NotFoundException;
+import es.upm.miw.apaw.domain.models.theater.TheaterHall;
+import es.upm.miw.apaw.domain.models.theater.TheaterVenue;
+import es.upm.miw.apaw.domain.persistenceports.theater.TheaterVenuePersistence;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Repository("theaterVenuePersistence")
+public class TheaterVenuePersistenceMongodb implements TheaterVenuePersistence {
+
+    private final TheaterVenueRepository theaterVenueRepository;
+    private final TheaterHallRepository theaterHallRepository;
+
+    @Autowired
+    public TheaterVenuePersistenceMongodb(
+            TheaterVenueRepository theaterVenueRepository,
+            TheaterHallRepository theaterHallRepository) {
+        this.theaterVenueRepository = theaterVenueRepository;
+        this.theaterHallRepository = theaterHallRepository;
+    }
+
+    @Override
+    public TheaterVenue create(TheaterVenue theaterVenue) {
+        TheaterVenueEntity entity = new TheaterVenueEntity(theaterVenue);
+        entity.setVenueHalls(toTheaterHallEntityList(theaterVenue.getVenueHalls()));
+        return this.theaterVenueRepository.save(entity).toTheaterVenue();
+    }
+
+    @Override
+    public TheaterVenue read(String venueCode) {
+        return this.theaterVenueRepository.findByVenueCode(venueCode)
+                .orElseThrow(() -> new NotFoundException("TheaterVenue venueCode: " + venueCode))
+                .toTheaterVenue();
+    }
+
+    @Override
+    public TheaterVenue update(String venueCode, TheaterVenue theaterVenue) {
+        TheaterVenueEntity entity = this.theaterVenueRepository.findByVenueCode(venueCode)
+                .orElseThrow(() -> new NotFoundException("TheaterVenue venueCode: " + venueCode));
+        entity.fromTheaterVenue(theaterVenue);
+        entity.setVenueHalls(toTheaterHallEntityList(theaterVenue.getVenueHalls()));
+        return this.theaterVenueRepository.save(entity).toTheaterVenue();
+    }
+
+    private List<TheaterHallEntity> toTheaterHallEntityList(List<TheaterHall> halls) {
+        if (halls == null || halls.isEmpty()) {
+            return List.of();
+        }
+        return halls.stream()
+                .map(hall -> {
+                    Optional<TheaterHallEntity> existing = theaterHallRepository.findByHallCode(hall.getHallCode());
+                    if (existing.isPresent()) {
+                        return existing.get();
+                    }
+                    TheaterHallEntity entity = new TheaterHallEntity();
+                    entity.fromTheaterHall(hall);
+                    return theaterHallRepository.save(entity);
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Stream<TheaterVenue> readAll() {
+        return this.theaterVenueRepository.findAll().stream()
+                .map(TheaterVenueEntity::toTheaterVenue);
+    }
+
+    @Override
+    public boolean existsByVenueCode(String venueCode) {
+        return this.theaterVenueRepository.findByVenueCode(venueCode).isPresent();
+    }
+
+    @Override
+    public Stream<TheaterHall> findHallsByVenueCode(String venueCode) {
+        return this.theaterVenueRepository.findByVenueCode(venueCode)
+                .orElseThrow(() -> new NotFoundException("TheaterVenue venueCode: " + venueCode))
+                .getVenueHalls()
+                .stream()
+                .map(TheaterHallEntity::toTheaterHall);
+    }
+}

--- a/src/main/java/es/upm/miw/apaw/domain/persistenceports/theater/TheaterArtistPersistence.java
+++ b/src/main/java/es/upm/miw/apaw/domain/persistenceports/theater/TheaterArtistPersistence.java
@@ -1,0 +1,20 @@
+package es.upm.miw.apaw.domain.persistenceports.theater;
+
+import es.upm.miw.apaw.domain.models.theater.TheaterArtist;
+import org.springframework.stereotype.Repository;
+
+import java.util.stream.Stream;
+
+@Repository
+public interface TheaterArtistPersistence {
+
+    TheaterArtist create(TheaterArtist theaterArtist);
+
+    TheaterArtist read(String artistCode);
+
+    TheaterArtist update(String artistCode, TheaterArtist theaterArtist);
+
+    Stream<TheaterArtist> readAll();
+
+    boolean existsByArtistCode(String artistCode);
+}

--- a/src/main/java/es/upm/miw/apaw/domain/persistenceports/theater/TheaterHallPersistence.java
+++ b/src/main/java/es/upm/miw/apaw/domain/persistenceports/theater/TheaterHallPersistence.java
@@ -1,0 +1,20 @@
+package es.upm.miw.apaw.domain.persistenceports.theater;
+
+import es.upm.miw.apaw.domain.models.theater.TheaterHall;
+import org.springframework.stereotype.Repository;
+
+import java.util.stream.Stream;
+
+@Repository
+public interface TheaterHallPersistence {
+
+    TheaterHall create(TheaterHall theaterHall);
+
+    TheaterHall read(String hallCode);
+
+    TheaterHall update(String hallCode, TheaterHall theaterHall);
+
+    Stream<TheaterHall> readAll();
+
+    boolean existsByHallCode(String hallCode);
+}

--- a/src/main/java/es/upm/miw/apaw/domain/persistenceports/theater/TheaterPerformancePersistence.java
+++ b/src/main/java/es/upm/miw/apaw/domain/persistenceports/theater/TheaterPerformancePersistence.java
@@ -1,0 +1,23 @@
+package es.upm.miw.apaw.domain.persistenceports.theater;
+
+import es.upm.miw.apaw.domain.models.theater.TheaterArtist;
+import es.upm.miw.apaw.domain.models.theater.TheaterPerformance;
+import org.springframework.stereotype.Repository;
+
+import java.util.stream.Stream;
+
+@Repository
+public interface TheaterPerformancePersistence {
+
+    TheaterPerformance create(TheaterPerformance theaterPerformance);
+
+    TheaterPerformance read(String performanceCode);
+
+    TheaterPerformance update(String performanceCode, TheaterPerformance theaterPerformance);
+
+    Stream<TheaterPerformance> readAll();
+
+    boolean existsByPerformanceCode(String performanceCode);
+
+    Stream<TheaterArtist> findArtistsByPerformanceCode(String performanceCode);
+}

--- a/src/main/java/es/upm/miw/apaw/domain/persistenceports/theater/TheaterVenuePersistence.java
+++ b/src/main/java/es/upm/miw/apaw/domain/persistenceports/theater/TheaterVenuePersistence.java
@@ -1,0 +1,23 @@
+package es.upm.miw.apaw.domain.persistenceports.theater;
+
+import es.upm.miw.apaw.domain.models.theater.TheaterHall;
+import es.upm.miw.apaw.domain.models.theater.TheaterVenue;
+import org.springframework.stereotype.Repository;
+
+import java.util.stream.Stream;
+
+@Repository
+public interface TheaterVenuePersistence {
+
+    TheaterVenue create(TheaterVenue theaterVenue);
+
+    TheaterVenue read(String venueCode);
+
+    TheaterVenue update(String venueCode, TheaterVenue theaterVenue);
+
+    Stream<TheaterVenue> readAll();
+
+    boolean existsByVenueCode(String venueCode);
+
+    Stream<TheaterHall> findHallsByVenueCode(String venueCode);
+}

--- a/src/test/java/es/upm/miw/apaw/BaseTheaterTests.java
+++ b/src/test/java/es/upm/miw/apaw/BaseTheaterTests.java
@@ -1,0 +1,124 @@
+package es.upm.miw.apaw;
+
+import es.upm.miw.apaw.adapters.mongodb.theater.daos.TheaterArtistRepository;
+import es.upm.miw.apaw.adapters.mongodb.theater.daos.TheaterHallRepository;
+import es.upm.miw.apaw.adapters.mongodb.theater.daos.TheaterPerformanceRepository;
+import es.upm.miw.apaw.adapters.mongodb.theater.daos.TheaterSeeder;
+import es.upm.miw.apaw.adapters.mongodb.theater.daos.TheaterVenueRepository;
+import es.upm.miw.apaw.adapters.mongodb.theater.entities.TheaterArtistEntity;
+import es.upm.miw.apaw.adapters.mongodb.theater.entities.TheaterHallEntity;
+import es.upm.miw.apaw.adapters.mongodb.theater.entities.TheaterPerformanceEntity;
+import es.upm.miw.apaw.adapters.mongodb.theater.entities.TheaterVenueEntity;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public abstract class BaseTheaterTests {
+
+    protected TheaterArtistEntity[] artists;
+    protected TheaterHallEntity[] halls;
+    protected TheaterVenueEntity[] venues;
+    protected TheaterPerformanceEntity[] performances;
+
+    @Autowired
+    protected TheaterArtistRepository theaterArtistRepository;
+
+    @Autowired
+    protected TheaterHallRepository theaterHallRepository;
+
+    @Autowired
+    protected TheaterVenueRepository theaterVenueRepository;
+
+    @Autowired
+    protected TheaterPerformanceRepository theaterPerformanceRepository;
+
+    @BeforeEach
+    void beforeEach() {
+        artists = new TheaterArtistEntity[]{
+                TheaterArtistEntity.builder()
+                        .id(UUID.randomUUID())
+                        .artistCode("TART01")
+                        .artistFullName("Alice Performer")
+                        .artistBirthDate(LocalDate.of(1992, 4, 10))
+                        .artistFee(new BigDecimal("800.00"))
+                        .artistActive(true)
+                        .build(),
+                TheaterArtistEntity.builder()
+                        .id(UUID.randomUUID())
+                        .artistCode("TART02")
+                        .artistFullName("Bob Dancer")
+                        .artistBirthDate(LocalDate.of(1988, 9, 25))
+                        .artistFee(new BigDecimal("950.00"))
+                        .artistActive(true)
+                        .build()
+        };
+
+        halls = new TheaterHallEntity[]{
+                TheaterHallEntity.builder()
+                        .id(UUID.randomUUID())
+                        .hallCode("THAL01")
+                        .hallName("Theater Hall A")
+                        .hallCapacity(300)
+                        .hallAccessible(true)
+                        .build(),
+                TheaterHallEntity.builder()
+                        .id(UUID.randomUUID())
+                        .hallCode("THAL02")
+                        .hallName("Theater Hall B")
+                        .hallCapacity(100)
+                        .hallAccessible(false)
+                        .build()
+        };
+
+        venues = new TheaterVenueEntity[]{
+                TheaterVenueEntity.builder()
+                        .id(UUID.randomUUID())
+                        .venueCode("TVEN01")
+                        .venueName("Test Theater")
+                        .venueCity("Madrid")
+                        .venueOpen(true)
+                        .venueCreatedAt(LocalDateTime.of(2023, 1, 1, 0, 0))
+                        .venueHalls(List.of(halls[0], halls[1]))
+                        .venueManagerId(UUID.randomUUID())
+                        .build()
+        };
+
+        performances = new TheaterPerformanceEntity[]{
+                TheaterPerformanceEntity.builder()
+                        .id(UUID.randomUUID())
+                        .performanceCode("TPER01")
+                        .performanceTitle("Test Play")
+                        .performanceDate(LocalDate.of(2026, 12, 1))
+                        .performanceDurationMinutes(90)
+                        .performanceTicketPrice(new BigDecimal("25.00"))
+                        .performanceHall(halls[0])
+                        .performanceArtists(new HashSet<>(List.of(artists[0])))
+                        .build()
+        };
+
+        theaterArtistRepository.saveAll(Arrays.asList(artists));
+        theaterHallRepository.saveAll(Arrays.asList(halls));
+        theaterVenueRepository.saveAll(Arrays.asList(venues));
+        theaterPerformanceRepository.saveAll(Arrays.asList(performances));
+    }
+
+    @AfterEach
+    void afterEach() {
+        theaterPerformanceRepository.deleteAll();
+        theaterVenueRepository.deleteAll();
+        theaterHallRepository.deleteAll();
+        theaterArtistRepository.deleteAll();
+    }
+}

--- a/src/test/java/es/upm/miw/apaw/adapters/mongodb/theater/daos/TheaterArtistRepositoryIT.java
+++ b/src/test/java/es/upm/miw/apaw/adapters/mongodb/theater/daos/TheaterArtistRepositoryIT.java
@@ -1,0 +1,43 @@
+package es.upm.miw.apaw.adapters.mongodb.theater.daos;
+
+import es.upm.miw.apaw.BaseTheaterTests;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TheaterArtistRepositoryIT extends BaseTheaterTests {
+
+    @Autowired
+    private TheaterArtistRepository theaterArtistRepository;
+
+    @Test
+    void testFindByArtistCode() {
+        assertThat(theaterArtistRepository.findByArtistCode(artists[0].getArtistCode()))
+                .isPresent()
+                .hasValueSatisfying(e -> {
+                    assertThat(e.getArtistCode()).isEqualTo(artists[0].getArtistCode());
+                    assertThat(e.getArtistFullName()).isEqualTo(artists[0].getArtistFullName());
+                    assertThat(e.getArtistBirthDate()).isEqualTo(artists[0].getArtistBirthDate());
+                    assertThat(e.getArtistFee()).isEqualTo(artists[0].getArtistFee());
+                    assertThat(e.getArtistActive()).isEqualTo(artists[0].getArtistActive());
+                });
+    }
+
+    @Test
+    void testFindByArtistCode_NotFound() {
+        assertThat(theaterArtistRepository.findByArtistCode("NONEXISTENT")).isEmpty();
+    }
+
+    @Test
+    void testDeleteByArtistCode() {
+        int deleted = theaterArtistRepository.deleteByArtistCode(artists[0].getArtistCode());
+        assertThat(deleted).isEqualTo(1);
+        assertThat(theaterArtistRepository.findByArtistCode(artists[0].getArtistCode())).isEmpty();
+    }
+
+    @Test
+    void testFindAll() {
+        assertThat(theaterArtistRepository.findAll()).hasSizeGreaterThanOrEqualTo(2);
+    }
+}

--- a/src/test/java/es/upm/miw/apaw/adapters/mongodb/theater/daos/TheaterHallRepositoryIT.java
+++ b/src/test/java/es/upm/miw/apaw/adapters/mongodb/theater/daos/TheaterHallRepositoryIT.java
@@ -1,0 +1,42 @@
+package es.upm.miw.apaw.adapters.mongodb.theater.daos;
+
+import es.upm.miw.apaw.BaseTheaterTests;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TheaterHallRepositoryIT extends BaseTheaterTests {
+
+    @Autowired
+    private TheaterHallRepository theaterHallRepository;
+
+    @Test
+    void testFindByHallCode() {
+        assertThat(theaterHallRepository.findByHallCode(halls[0].getHallCode()))
+                .isPresent()
+                .hasValueSatisfying(e -> {
+                    assertThat(e.getHallCode()).isEqualTo(halls[0].getHallCode());
+                    assertThat(e.getHallName()).isEqualTo(halls[0].getHallName());
+                    assertThat(e.getHallCapacity()).isEqualTo(halls[0].getHallCapacity());
+                    assertThat(e.getHallAccessible()).isEqualTo(halls[0].getHallAccessible());
+                });
+    }
+
+    @Test
+    void testFindByHallCode_NotFound() {
+        assertThat(theaterHallRepository.findByHallCode("NONEXISTENT")).isEmpty();
+    }
+
+    @Test
+    void testDeleteByHallCode() {
+        int deleted = theaterHallRepository.deleteByHallCode(halls[0].getHallCode());
+        assertThat(deleted).isEqualTo(1);
+        assertThat(theaterHallRepository.findByHallCode(halls[0].getHallCode())).isEmpty();
+    }
+
+    @Test
+    void testFindAll() {
+        assertThat(theaterHallRepository.findAll()).hasSizeGreaterThanOrEqualTo(2);
+    }
+}

--- a/src/test/java/es/upm/miw/apaw/adapters/mongodb/theater/daos/TheaterPerformanceRepositoryIT.java
+++ b/src/test/java/es/upm/miw/apaw/adapters/mongodb/theater/daos/TheaterPerformanceRepositoryIT.java
@@ -1,0 +1,45 @@
+package es.upm.miw.apaw.adapters.mongodb.theater.daos;
+
+import es.upm.miw.apaw.BaseTheaterTests;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TheaterPerformanceRepositoryIT extends BaseTheaterTests {
+
+    @Autowired
+    private TheaterPerformanceRepository theaterPerformanceRepository;
+
+    @Test
+    void testFindByPerformanceCode() {
+        assertThat(theaterPerformanceRepository.findByPerformanceCode(performances[0].getPerformanceCode()))
+                .isPresent()
+                .hasValueSatisfying(e -> {
+                    assertThat(e.getPerformanceCode()).isEqualTo(performances[0].getPerformanceCode());
+                    assertThat(e.getPerformanceTitle()).isEqualTo(performances[0].getPerformanceTitle());
+                    assertThat(e.getPerformanceDate()).isEqualTo(performances[0].getPerformanceDate());
+                    assertThat(e.getPerformanceDurationMinutes()).isEqualTo(performances[0].getPerformanceDurationMinutes());
+                    assertThat(e.getPerformanceTicketPrice()).isEqualTo(performances[0].getPerformanceTicketPrice());
+                    assertThat(e.getPerformanceHall()).isNotNull();
+                    assertThat(e.getPerformanceArtists()).hasSize(1);
+                });
+    }
+
+    @Test
+    void testFindByPerformanceCode_NotFound() {
+        assertThat(theaterPerformanceRepository.findByPerformanceCode("NONEXISTENT")).isEmpty();
+    }
+
+    @Test
+    void testDeleteByPerformanceCode() {
+        int deleted = theaterPerformanceRepository.deleteByPerformanceCode(performances[0].getPerformanceCode());
+        assertThat(deleted).isEqualTo(1);
+        assertThat(theaterPerformanceRepository.findByPerformanceCode(performances[0].getPerformanceCode())).isEmpty();
+    }
+
+    @Test
+    void testFindAll() {
+        assertThat(theaterPerformanceRepository.findAll()).hasSizeGreaterThanOrEqualTo(1);
+    }
+}

--- a/src/test/java/es/upm/miw/apaw/adapters/mongodb/theater/daos/TheaterVenueRepositoryIT.java
+++ b/src/test/java/es/upm/miw/apaw/adapters/mongodb/theater/daos/TheaterVenueRepositoryIT.java
@@ -1,0 +1,44 @@
+package es.upm.miw.apaw.adapters.mongodb.theater.daos;
+
+import es.upm.miw.apaw.BaseTheaterTests;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TheaterVenueRepositoryIT extends BaseTheaterTests {
+
+    @Autowired
+    private TheaterVenueRepository theaterVenueRepository;
+
+    @Test
+    void testFindByVenueCode() {
+        assertThat(theaterVenueRepository.findByVenueCode(venues[0].getVenueCode()))
+                .isPresent()
+                .hasValueSatisfying(e -> {
+                    assertThat(e.getVenueCode()).isEqualTo(venues[0].getVenueCode());
+                    assertThat(e.getVenueName()).isEqualTo(venues[0].getVenueName());
+                    assertThat(e.getVenueCity()).isEqualTo(venues[0].getVenueCity());
+                    assertThat(e.getVenueOpen()).isEqualTo(venues[0].getVenueOpen());
+                    assertThat(e.getVenueManagerId()).isEqualTo(venues[0].getVenueManagerId());
+                    assertThat(e.getVenueHalls()).hasSize(2);
+                });
+    }
+
+    @Test
+    void testFindByVenueCode_NotFound() {
+        assertThat(theaterVenueRepository.findByVenueCode("NONEXISTENT")).isEmpty();
+    }
+
+    @Test
+    void testDeleteByVenueCode() {
+        int deleted = theaterVenueRepository.deleteByVenueCode(venues[0].getVenueCode());
+        assertThat(deleted).isEqualTo(1);
+        assertThat(theaterVenueRepository.findByVenueCode(venues[0].getVenueCode())).isEmpty();
+    }
+
+    @Test
+    void testFindAll() {
+        assertThat(theaterVenueRepository.findAll()).hasSizeGreaterThanOrEqualTo(1);
+    }
+}

--- a/src/test/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterArtistPersistenceMongodbIT.java
+++ b/src/test/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterArtistPersistenceMongodbIT.java
@@ -1,0 +1,101 @@
+package es.upm.miw.apaw.adapters.mongodb.theater.persistence;
+
+import es.upm.miw.apaw.BaseTheaterTests;
+import es.upm.miw.apaw.adapters.mongodb.theater.daos.TheaterArtistRepository;
+import es.upm.miw.apaw.domain.exceptions.NotFoundException;
+import es.upm.miw.apaw.domain.models.theater.TheaterArtist;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TheaterArtistPersistenceMongodbIT extends BaseTheaterTests {
+
+    @Autowired
+    private TheaterArtistPersistenceMongodb theaterArtistPersistenceMongodb;
+
+    @Autowired
+    private TheaterArtistRepository theaterArtistRepository;
+
+    @Test
+    void testCreateAndRead() {
+        TheaterArtist artist = TheaterArtist.builder()
+                .artistCode("TARTCR")
+                .artistFullName("Create Test Artist")
+                .artistBirthDate(LocalDate.of(1993, 5, 20))
+                .artistFee(new BigDecimal("700.00"))
+                .artistActive(true)
+                .build();
+        theaterArtistPersistenceMongodb.create(artist);
+        TheaterArtist read = theaterArtistPersistenceMongodb.read("TARTCR");
+        assertThat(read.getArtistCode()).isEqualTo("TARTCR");
+        assertThat(read.getArtistFullName()).isEqualTo("Create Test Artist");
+        assertThat(read.getArtistBirthDate()).isEqualTo(LocalDate.of(1993, 5, 20));
+        assertThat(read.getArtistFee()).isEqualTo(new BigDecimal("700.00"));
+        assertThat(read.getArtistActive()).isTrue();
+        theaterArtistRepository.deleteByArtistCode("TARTCR");
+    }
+
+    @Test
+    void testRead_NotFound() {
+        assertThrows(NotFoundException.class, () -> theaterArtistPersistenceMongodb.read("NONEXISTENT"));
+    }
+
+    @Test
+    void testUpdate() {
+        TheaterArtist artist = TheaterArtist.builder()
+                .artistCode("TARTUP")
+                .artistFullName("Update Test Artist")
+                .artistBirthDate(LocalDate.of(1994, 1, 1))
+                .artistFee(new BigDecimal("500.00"))
+                .artistActive(true)
+                .build();
+        theaterArtistPersistenceMongodb.create(artist);
+        artist.setArtistFullName("Updated Name");
+        artist.setArtistFee(new BigDecimal("600.00"));
+        artist.setArtistActive(false);
+        TheaterArtist updated = theaterArtistPersistenceMongodb.update("TARTUP", artist);
+        assertThat(updated.getArtistFullName()).isEqualTo("Updated Name");
+        assertThat(updated.getArtistFee()).isEqualTo(new BigDecimal("600.00"));
+        assertThat(updated.getArtistActive()).isFalse();
+        theaterArtistRepository.deleteByArtistCode("TARTUP");
+    }
+
+    @Test
+    void testUpdate_NotFound() {
+        TheaterArtist artist = TheaterArtist.builder()
+                .artistCode("NONEXISTENT")
+                .artistFullName("No Name")
+                .artistBirthDate(LocalDate.of(1995, 1, 1))
+                .artistFee(new BigDecimal("100.00"))
+                .artistActive(true)
+                .build();
+        assertThrows(NotFoundException.class, () -> theaterArtistPersistenceMongodb.update("NONEXISTENT", artist));
+    }
+
+    @Test
+    void testReadAll() {
+        long initial = theaterArtistPersistenceMongodb.readAll().count();
+        TheaterArtist artist = TheaterArtist.builder()
+                .artistCode("TARTRA")
+                .artistFullName("ReadAll Test")
+                .artistBirthDate(LocalDate.of(1996, 3, 3))
+                .artistFee(new BigDecimal("300.00"))
+                .artistActive(false)
+                .build();
+        theaterArtistPersistenceMongodb.create(artist);
+        assertThat(theaterArtistPersistenceMongodb.readAll().count()).isEqualTo(initial + 1);
+        theaterArtistRepository.deleteByArtistCode("TARTRA");
+    }
+
+    @Test
+    void testExistsByArtistCode() {
+        assertThat(theaterArtistPersistenceMongodb.existsByArtistCode(artists[0].getArtistCode())).isTrue();
+        assertThat(theaterArtistPersistenceMongodb.existsByArtistCode("NONEXISTENT")).isFalse();
+    }
+}

--- a/src/test/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterHallPersistenceMongodbIT.java
+++ b/src/test/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterHallPersistenceMongodbIT.java
@@ -1,0 +1,92 @@
+package es.upm.miw.apaw.adapters.mongodb.theater.persistence;
+
+import es.upm.miw.apaw.BaseTheaterTests;
+import es.upm.miw.apaw.adapters.mongodb.theater.daos.TheaterHallRepository;
+import es.upm.miw.apaw.domain.exceptions.NotFoundException;
+import es.upm.miw.apaw.domain.models.theater.TheaterHall;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TheaterHallPersistenceMongodbIT extends BaseTheaterTests {
+
+    @Autowired
+    private TheaterHallPersistenceMongodb theaterHallPersistenceMongodb;
+
+    @Autowired
+    private TheaterHallRepository theaterHallRepository;
+
+    @Test
+    void testCreateAndRead() {
+        TheaterHall hall = TheaterHall.builder()
+                .hallCode("THLCR")
+                .hallName("New Test Hall")
+                .hallCapacity(200)
+                .hallAccessible(true)
+                .build();
+        theaterHallPersistenceMongodb.create(hall);
+        TheaterHall read = theaterHallPersistenceMongodb.read("THLCR");
+        assertThat(read.getHallCode()).isEqualTo("THLCR");
+        assertThat(read.getHallName()).isEqualTo("New Test Hall");
+        assertThat(read.getHallCapacity()).isEqualTo(200);
+        assertThat(read.getHallAccessible()).isTrue();
+        theaterHallRepository.deleteByHallCode("THLCR");
+    }
+
+    @Test
+    void testRead_NotFound() {
+        assertThrows(NotFoundException.class, () -> theaterHallPersistenceMongodb.read("NONEXISTENT"));
+    }
+
+    @Test
+    void testUpdate() {
+        TheaterHall hall = TheaterHall.builder()
+                .hallCode("THLUP")
+                .hallName("Original Hall")
+                .hallCapacity(150)
+                .hallAccessible(false)
+                .build();
+        theaterHallPersistenceMongodb.create(hall);
+        hall.setHallName("Updated Hall");
+        hall.setHallCapacity(180);
+        hall.setHallAccessible(true);
+        TheaterHall updated = theaterHallPersistenceMongodb.update("THLUP", hall);
+        assertThat(updated.getHallName()).isEqualTo("Updated Hall");
+        assertThat(updated.getHallCapacity()).isEqualTo(180);
+        assertThat(updated.getHallAccessible()).isTrue();
+        theaterHallRepository.deleteByHallCode("THLUP");
+    }
+
+    @Test
+    void testUpdate_NotFound() {
+        TheaterHall hall = TheaterHall.builder()
+                .hallCode("NONEXISTENT")
+                .hallName("No Hall")
+                .hallCapacity(0)
+                .hallAccessible(false)
+                .build();
+        assertThrows(NotFoundException.class, () -> theaterHallPersistenceMongodb.update("NONEXISTENT", hall));
+    }
+
+    @Test
+    void testReadAll() {
+        long initial = theaterHallPersistenceMongodb.readAll().count();
+        TheaterHall hall = TheaterHall.builder()
+                .hallCode("THLRA")
+                .hallName("ReadAll Hall")
+                .hallCapacity(50)
+                .hallAccessible(true)
+                .build();
+        theaterHallPersistenceMongodb.create(hall);
+        assertThat(theaterHallPersistenceMongodb.readAll().count()).isEqualTo(initial + 1);
+        theaterHallRepository.deleteByHallCode("THLRA");
+    }
+
+    @Test
+    void testExistsByHallCode() {
+        assertThat(theaterHallPersistenceMongodb.existsByHallCode(halls[0].getHallCode())).isTrue();
+        assertThat(theaterHallPersistenceMongodb.existsByHallCode("NONEXISTENT")).isFalse();
+    }
+}

--- a/src/test/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterPerformancePersistenceMongodbIT.java
+++ b/src/test/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterPerformancePersistenceMongodbIT.java
@@ -1,0 +1,149 @@
+package es.upm.miw.apaw.adapters.mongodb.theater.persistence;
+
+import es.upm.miw.apaw.BaseTheaterTests;
+import es.upm.miw.apaw.adapters.mongodb.theater.daos.TheaterPerformanceRepository;
+import es.upm.miw.apaw.domain.exceptions.NotFoundException;
+import es.upm.miw.apaw.domain.models.theater.TheaterArtist;
+import es.upm.miw.apaw.domain.models.theater.TheaterHall;
+import es.upm.miw.apaw.domain.models.theater.TheaterPerformance;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TheaterPerformancePersistenceMongodbIT extends BaseTheaterTests {
+
+    @Autowired
+    private TheaterPerformancePersistenceMongodb theaterPerformancePersistenceMongodb;
+
+    @Autowired
+    private TheaterPerformanceRepository theaterPerformanceRepository;
+
+    @Test
+    void testCreateAndRead() {
+        TheaterPerformance perf = TheaterPerformance.builder()
+                .performanceCode("TPPCR")
+                .performanceTitle("Create Test Play")
+                .performanceDate(LocalDate.of(2027, 1, 1))
+                .performanceDurationMinutes(120)
+                .performanceTicketPrice(new BigDecimal("35.00"))
+                .performanceHall(halls[0].toTheaterHall())
+                .performanceArtists(Set.of(artists[0].toTheaterArtist()))
+                .build();
+        theaterPerformancePersistenceMongodb.create(perf);
+        TheaterPerformance read = theaterPerformancePersistenceMongodb.read("TPPCR");
+        assertThat(read.getPerformanceCode()).isEqualTo("TPPCR");
+        assertThat(read.getPerformanceTitle()).isEqualTo("Create Test Play");
+        assertThat(read.getPerformanceDate()).isEqualTo(LocalDate.of(2027, 1, 1));
+        assertThat(read.getPerformanceDurationMinutes()).isEqualTo(120);
+        assertThat(read.getPerformanceTicketPrice()).isEqualTo(new BigDecimal("35.00"));
+        assertThat(read.getPerformanceHall()).isNotNull();
+        assertThat(read.getPerformanceArtists()).hasSize(1);
+        theaterPerformanceRepository.deleteByPerformanceCode("TPPCR");
+    }
+
+    @Test
+    void testRead_NotFound() {
+        assertThrows(NotFoundException.class, () -> theaterPerformancePersistenceMongodb.read("NONEXISTENT"));
+    }
+
+    @Test
+    void testUpdate() {
+        TheaterPerformance perf = TheaterPerformance.builder()
+                .performanceCode("TPPUP")
+                .performanceTitle("Original Play")
+                .performanceDate(LocalDate.of(2027, 2, 1))
+                .performanceDurationMinutes(90)
+                .performanceTicketPrice(new BigDecimal("20.00"))
+                .performanceHall(halls[0].toTheaterHall())
+                .performanceArtists(Set.of(artists[0].toTheaterArtist()))
+                .build();
+        theaterPerformancePersistenceMongodb.create(perf);
+        perf.setPerformanceTitle("Updated Play");
+        perf.setPerformanceTicketPrice(new BigDecimal("25.00"));
+        TheaterPerformance updated = theaterPerformancePersistenceMongodb.update("TPPUP", perf);
+        assertThat(updated.getPerformanceTitle()).isEqualTo("Updated Play");
+        assertThat(updated.getPerformanceTicketPrice()).isEqualTo(new BigDecimal("25.00"));
+        theaterPerformanceRepository.deleteByPerformanceCode("TPPUP");
+    }
+
+    @Test
+    void testUpdate_NotFound() {
+        TheaterPerformance perf = TheaterPerformance.builder()
+                .performanceCode("NONEXISTENT")
+                .performanceTitle("No Play")
+                .performanceDate(LocalDate.of(2027, 3, 1))
+                .performanceDurationMinutes(60)
+                .performanceTicketPrice(new BigDecimal("10.00"))
+                .performanceHall(halls[0].toTheaterHall())
+                .performanceArtists(Set.of())
+                .build();
+        assertThrows(NotFoundException.class, () -> theaterPerformancePersistenceMongodb.update("NONEXISTENT", perf));
+    }
+
+    @Test
+    void testReadAll() {
+        long initial = theaterPerformancePersistenceMongodb.readAll().count();
+        TheaterPerformance perf = TheaterPerformance.builder()
+                .performanceCode("TPPDA")
+                .performanceTitle("ReadAll Play")
+                .performanceDate(LocalDate.of(2027, 4, 1))
+                .performanceDurationMinutes(75)
+                .performanceTicketPrice(new BigDecimal("15.00"))
+                .performanceHall(halls[0].toTheaterHall())
+                .performanceArtists(Set.of())
+                .build();
+        theaterPerformancePersistenceMongodb.create(perf);
+        assertThat(theaterPerformancePersistenceMongodb.readAll().count()).isEqualTo(initial + 1);
+        theaterPerformanceRepository.deleteByPerformanceCode("TPPDA");
+    }
+
+    @Test
+    void testExistsByPerformanceCode() {
+        assertThat(theaterPerformancePersistenceMongodb.existsByPerformanceCode(performances[0].getPerformanceCode())).isTrue();
+        assertThat(theaterPerformancePersistenceMongodb.existsByPerformanceCode("NONEXISTENT")).isFalse();
+    }
+
+    @Test
+    void testFindArtistsByPerformanceCode() {
+        var artists = theaterPerformancePersistenceMongodb.findArtistsByPerformanceCode(performances[0].getPerformanceCode()).toList();
+        assertThat(artists).hasSize(1);
+    }
+
+    @Test
+    void testFindArtistsByPerformanceCode_NotFound() {
+        assertThrows(NotFoundException.class,
+                () -> theaterPerformancePersistenceMongodb.findArtistsByPerformanceCode("NONEXISTENT"));
+    }
+
+    @Test
+    void testPerformanceToHallUnidirectionalRelationship() {
+        TheaterPerformance read = theaterPerformancePersistenceMongodb.read(performances[0].getPerformanceCode());
+        TheaterHall hall = read.getPerformanceHall();
+        assertThat(hall.getHallCode()).isNotNull();
+        assertThat(hall.getHallName()).isNotNull();
+        assertThat(hall.getHallCapacity()).isNotNull();
+        assertThat(hall.getHallAccessible()).isNotNull();
+    }
+
+    @Test
+    void testPerformanceToArtistUnidirectionalRelationship() {
+        TheaterPerformance read = theaterPerformancePersistenceMongodb.read(performances[0].getPerformanceCode());
+        Set<TheaterArtist> artistSet = read.getPerformanceArtists();
+        assertThat(artistSet).isNotEmpty();
+        artistSet.forEach(artist -> {
+            assertThat(artist.getArtistCode()).isNotNull();
+            assertThat(artist.getArtistFullName()).isNotNull();
+            assertThat(artist.getArtistBirthDate()).isNotNull();
+            assertThat(artist.getArtistFee()).isNotNull();
+            assertThat(artist.getArtistActive()).isNotNull();
+        });
+    }
+}

--- a/src/test/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterVenuePersistenceMongodbIT.java
+++ b/src/test/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterVenuePersistenceMongodbIT.java
@@ -1,0 +1,135 @@
+package es.upm.miw.apaw.adapters.mongodb.theater.persistence;
+
+import es.upm.miw.apaw.BaseTheaterTests;
+import es.upm.miw.apaw.adapters.mongodb.theater.daos.TheaterVenueRepository;
+import es.upm.miw.apaw.domain.exceptions.NotFoundException;
+import es.upm.miw.apaw.domain.models.UserDto;
+import es.upm.miw.apaw.domain.models.theater.TheaterHall;
+import es.upm.miw.apaw.domain.models.theater.TheaterVenue;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TheaterVenuePersistenceMongodbIT extends BaseTheaterTests {
+
+    @Autowired
+    private TheaterVenuePersistenceMongodb theaterVenuePersistenceMongodb;
+
+    @Autowired
+    private TheaterVenueRepository theaterVenueRepository;
+
+    @Test
+    void testCreateAndRead() {
+        TheaterVenue venue = TheaterVenue.builder()
+                .venueCode("TVPCR")
+                .venueName("Create Test Venue")
+                .venueCity("Valencia")
+                .venueOpen(true)
+                .venueCreatedAt(LocalDateTime.of(2024, 2, 15, 0, 0))
+                .venueHalls(List.of())
+                .venueManager(UserDto.builder().id(UUID.randomUUID()).build())
+                .build();
+        theaterVenuePersistenceMongodb.create(venue);
+        TheaterVenue read = theaterVenuePersistenceMongodb.read("TVPCR");
+        assertThat(read.getVenueCode()).isEqualTo("TVPCR");
+        assertThat(read.getVenueName()).isEqualTo("Create Test Venue");
+        assertThat(read.getVenueCity()).isEqualTo("Valencia");
+        assertThat(read.getVenueOpen()).isTrue();
+        assertThat(read.getVenueManager()).isNotNull();
+        theaterVenueRepository.deleteByVenueCode("TVPCR");
+    }
+
+    @Test
+    void testRead_NotFound() {
+        assertThrows(NotFoundException.class, () -> theaterVenuePersistenceMongodb.read("NONEXISTENT"));
+    }
+
+    @Test
+    void testUpdate() {
+        TheaterVenue venue = TheaterVenue.builder()
+                .venueCode("TVPUP")
+                .venueName("Original Venue")
+                .venueCity("Seville")
+                .venueOpen(true)
+                .venueCreatedAt(LocalDateTime.of(2024, 3, 1, 0, 0))
+                .venueHalls(List.of())
+                .venueManager(UserDto.builder().id(UUID.randomUUID()).build())
+                .build();
+        theaterVenuePersistenceMongodb.create(venue);
+        venue.setVenueName("Updated Venue");
+        venue.setVenueCity("Bilbao");
+        venue.setVenueOpen(false);
+        TheaterVenue updated = theaterVenuePersistenceMongodb.update("TVPUP", venue);
+        assertThat(updated.getVenueName()).isEqualTo("Updated Venue");
+        assertThat(updated.getVenueCity()).isEqualTo("Bilbao");
+        assertThat(updated.getVenueOpen()).isFalse();
+        theaterVenueRepository.deleteByVenueCode("TVPUP");
+    }
+
+    @Test
+    void testUpdate_NotFound() {
+        TheaterVenue venue = TheaterVenue.builder()
+                .venueCode("NONEXISTENT")
+                .venueName("No Venue")
+                .venueCity("Nowhere")
+                .venueOpen(false)
+                .venueCreatedAt(LocalDateTime.now())
+                .venueHalls(List.of())
+                .venueManager(UserDto.builder().id(UUID.randomUUID()).build())
+                .build();
+        assertThrows(NotFoundException.class, () -> theaterVenuePersistenceMongodb.update("NONEXISTENT", venue));
+    }
+
+    @Test
+    void testReadAll() {
+        long initial = theaterVenuePersistenceMongodb.readAll().count();
+        TheaterVenue venue = TheaterVenue.builder()
+                .venueCode("TVPRA")
+                .venueName("ReadAll Venue")
+                .venueCity("Malaga")
+                .venueOpen(true)
+                .venueCreatedAt(LocalDateTime.of(2024, 4, 10, 0, 0))
+                .venueHalls(List.of())
+                .venueManager(UserDto.builder().id(UUID.randomUUID()).build())
+                .build();
+        theaterVenuePersistenceMongodb.create(venue);
+        assertThat(theaterVenuePersistenceMongodb.readAll().count()).isEqualTo(initial + 1);
+        theaterVenueRepository.deleteByVenueCode("TVPRA");
+    }
+
+    @Test
+    void testExistsByVenueCode() {
+        assertThat(theaterVenuePersistenceMongodb.existsByVenueCode(venues[0].getVenueCode())).isTrue();
+        assertThat(theaterVenuePersistenceMongodb.existsByVenueCode("NONEXISTENT")).isFalse();
+    }
+
+    @Test
+    void testFindHallsByVenueCode() {
+        var halls = theaterVenuePersistenceMongodb.findHallsByVenueCode(venues[0].getVenueCode()).toList();
+        assertThat(halls).hasSize(2);
+    }
+
+    @Test
+    void testFindHallsByVenueCode_NotFound() {
+        assertThrows(NotFoundException.class,
+                () -> theaterVenuePersistenceMongodb.findHallsByVenueCode("NONEXISTENT"));
+    }
+
+    @Test
+    void testVenueToHallUnidirectionalRelationship() {
+        TheaterVenue read = theaterVenuePersistenceMongodb.read(venues[0].getVenueCode());
+        assertThat(read.getVenueHalls()).hasSize(2);
+        TheaterHall firstHall = read.getVenueHalls().get(0);
+        assertThat(firstHall.getHallCode()).isNotNull();
+        assertThat(firstHall.getHallName()).isNotNull();
+        assertThat(firstHall.getHallCapacity()).isNotNull();
+        assertThat(firstHall.getHallAccessible()).isNotNull();
+        assertThat(firstHall).isNotNull();
+    }
+}


### PR DESCRIPTION
Related to #1380.

This PR implements the persistence layer for the Theater story.

Context:
- The Theater model issue is #1374.
- The unidirectional relationship correction was merged into develop through PR #1378.
- The teacher has already been notified for review.
- Issue #1374 remains open until the teacher confirms the corrected model.

Scope:
- Adds Theater MongoDB entities.
- Adds Theater repositories / DAOs.
- Adds Theater domain persistence ports.
- Adds Theater Mongo persistence adapters.
- Adds TheaterSeeder.
- Integrates TheaterSeeder with the global DatabaseSeeder.
- Adds Theater repository and persistence integration tests.

Out of scope:
- No REST resources / endpoints.
- No services.
- No search endpoints.
- No Theater domain model changes.
- No pom.xml, CI or Docker changes.

Validation:
- mvn -q -DskipTests compile
- mvn -q "-Dtest=*Theater*" test
- mvn -q test

Important:
- This PR is prepared because the deadline is close.
- The model issue #1374 should not be closed until the teacher confirms it.