### PR TITLE
Add theater GET venue endpoint #1382

### DIFF
--- a/src/main/java/es/upm/miw/apaw/adapters/resources/theater/TheaterVenueResource.java
+++ b/src/main/java/es/upm/miw/apaw/adapters/resources/theater/TheaterVenueResource.java
@@ -1,0 +1,30 @@
+package es.upm.miw.apaw.adapters.resources.theater;
+
+import es.upm.miw.apaw.domain.models.theater.TheaterVenue;
+import es.upm.miw.apaw.domain.services.theater.TheaterVenueService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(TheaterVenueResource.VENUES)
+public class TheaterVenueResource {
+
+    public static final String VENUES = "/theater/venues";
+    public static final String VENUE_CODE = "/{venueCode}";
+
+    private final TheaterVenueService theaterVenueService;
+
+    @Autowired
+    public TheaterVenueResource(TheaterVenueService theaterVenueService) {
+        this.theaterVenueService = theaterVenueService;
+    }
+
+    @GetMapping(VENUE_CODE)
+    public TheaterVenue read(@Valid @PathVariable String venueCode) {
+        return this.theaterVenueService.read(venueCode);
+    }
+}

--- a/src/main/java/es/upm/miw/apaw/domain/services/theater/TheaterVenueService.java
+++ b/src/main/java/es/upm/miw/apaw/domain/services/theater/TheaterVenueService.java
@@ -1,0 +1,21 @@
+package es.upm.miw.apaw.domain.services.theater;
+
+import es.upm.miw.apaw.domain.models.theater.TheaterVenue;
+import es.upm.miw.apaw.domain.persistenceports.theater.TheaterVenuePersistence;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TheaterVenueService {
+
+    private final TheaterVenuePersistence theaterVenuePersistence;
+
+    @Autowired
+    public TheaterVenueService(TheaterVenuePersistence theaterVenuePersistence) {
+        this.theaterVenuePersistence = theaterVenuePersistence;
+    }
+
+    public TheaterVenue read(String venueCode) {
+        return this.theaterVenuePersistence.read(venueCode);
+    }
+}

--- a/src/test/java/es/upm/miw/apaw/domain/services/theater/TheaterVenueServiceTest.java
+++ b/src/test/java/es/upm/miw/apaw/domain/services/theater/TheaterVenueServiceTest.java
@@ -1,0 +1,69 @@
+package es.upm.miw.apaw.domain.services.theater;
+
+import es.upm.miw.apaw.domain.exceptions.NotFoundException;
+import es.upm.miw.apaw.domain.models.UserDto;
+import es.upm.miw.apaw.domain.models.theater.TheaterHall;
+import es.upm.miw.apaw.domain.models.theater.TheaterVenue;
+import es.upm.miw.apaw.domain.persistenceports.theater.TheaterVenuePersistence;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class TheaterVenueServiceTest {
+
+    @Autowired
+    private TheaterVenueService theaterVenueService;
+
+    @MockitoBean
+    private TheaterVenuePersistence theaterVenuePersistence;
+
+    @Test
+    void testRead() {
+        TheaterVenue venue = TheaterVenue.builder()
+                .venueCode("TVEN01")
+                .venueName("Gran Teatro")
+                .venueCity("Madrid")
+                .venueOpen(true)
+                .venueCreatedAt(LocalDateTime.of(2020, 1, 10, 0, 0))
+                .venueHalls(List.of(
+                        TheaterHall.builder().hallCode("HAL01").hallName("Main Stage").hallCapacity(500).hallAccessible(true).build()
+                ))
+                .venueManager(UserDto.builder().id(UUID.randomUUID()).build())
+                .build();
+        BDDMockito.given(this.theaterVenuePersistence.read("TVEN01")).willReturn(venue);
+
+        TheaterVenue result = this.theaterVenueService.read("TVEN01");
+
+        assertThat(result.getVenueCode()).isEqualTo("TVEN01");
+        assertThat(result.getVenueName()).isEqualTo("Gran Teatro");
+        assertThat(result.getVenueCity()).isEqualTo("Madrid");
+        assertThat(result.getVenueOpen()).isTrue();
+        assertThat(result.getVenueHalls()).hasSize(1);
+        assertThat(result.getVenueHalls().getFirst().getHallCode()).isEqualTo("HAL01");
+        assertThat(result.getVenueManager()).isNotNull();
+        BDDMockito.then(this.theaterVenuePersistence).should().read("TVEN01");
+    }
+
+    @Test
+    void testRead_NotFound() {
+        BDDMockito.given(this.theaterVenuePersistence.read("NONEXISTENT"))
+                .willThrow(new NotFoundException("TheaterVenue venueCode: NONEXISTENT"));
+
+        assertThatThrownBy(() -> this.theaterVenueService.read("NONEXISTENT"))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("NONEXISTENT");
+    }
+}

--- a/src/test/java/es/upm/miw/apaw/functionaltests/theater/TheaterVenueResourceFT.java
+++ b/src/test/java/es/upm/miw/apaw/functionaltests/theater/TheaterVenueResourceFT.java
@@ -1,0 +1,48 @@
+package es.upm.miw.apaw.functionaltests.theater;
+
+import es.upm.miw.apaw.BaseTheaterTests;
+import es.upm.miw.apaw.adapters.resources.theater.TheaterVenueResource;
+import es.upm.miw.apaw.domain.models.theater.TheaterVenue;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@ActiveProfiles("test")
+class TheaterVenueResourceFT extends BaseTheaterTests {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Test
+    void testRead() {
+        webTestClient.get()
+                .uri(TheaterVenueResource.VENUES + TheaterVenueResource.VENUE_CODE, "TVEN01")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(TheaterVenue.class)
+                .value(venue -> {
+                    assertThat(venue).isNotNull();
+                    assertThat(venue.getVenueCode()).isEqualTo("TVEN01");
+                    assertThat(venue.getVenueName()).isEqualTo("Test Theater");
+                    assertThat(venue.getVenueCity()).isEqualTo("Madrid");
+                    assertThat(venue.getVenueOpen()).isTrue();
+                    assertThat(venue.getVenueHalls()).hasSize(2);
+                    assertThat(venue.getVenueManager()).isNotNull();
+                });
+    }
+
+    @Test
+    void testRead_NotFound() {
+        webTestClient.get()
+                .uri(TheaterVenueResource.VENUES + TheaterVenueResource.VENUE_CODE, "NONEXISTENT")
+                .exchange()
+                .expectStatus().isNotFound();
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements the first REST endpoint for story:theater.

Endpoint:

GET /theater/venues/{venueCode}

## Changes

- Add TheaterVenueService.
- Add TheaterVenueResource.
- Add service tests for TheaterVenueService.
- Add functional tests for GET /theater/venues/{venueCode}.

## Scope

This PR only implements the GET endpoint for Theater venues.

Out of scope:
- No POST endpoint.
- No PUT endpoint.
- No DELETE endpoint.
- No PATCH endpoint.
- No search endpoints.
- No changes to Theater domain model.
- No changes to Theater persistence behavior.
- No changes to unrelated stories.

## Validation

- mvn -q -DskipTests compile
- mvn -q "-Dtest=*Theater*" test
- mvn -q test

All commands passed locally.

## Notes

Related issue: #1382

Theater model issue #1374 and persistence issue #1380 remain open while waiting for teacher confirmation, but their code has already been merged into develop.