### PR TITLE
Add theater POST artist endpoint #1384

### DIFF
--- a/src/main/java/es/upm/miw/apaw/adapters/resources/theater/TheaterArtistResource.java
+++ b/src/main/java/es/upm/miw/apaw/adapters/resources/theater/TheaterArtistResource.java
@@ -1,0 +1,29 @@
+package es.upm.miw.apaw.adapters.resources.theater;
+
+import es.upm.miw.apaw.domain.models.theater.TheaterArtist;
+import es.upm.miw.apaw.domain.services.theater.TheaterArtistService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(TheaterArtistResource.ARTISTS)
+public class TheaterArtistResource {
+
+    public static final String ARTISTS = "/theater/artists";
+
+    private final TheaterArtistService theaterArtistService;
+
+    @Autowired
+    public TheaterArtistResource(TheaterArtistService theaterArtistService) {
+        this.theaterArtistService = theaterArtistService;
+    }
+
+    @PostMapping
+    public TheaterArtist create(@Valid @RequestBody TheaterArtist theaterArtist) {
+        return this.theaterArtistService.create(theaterArtist);
+    }
+}

--- a/src/main/java/es/upm/miw/apaw/domain/services/theater/TheaterArtistService.java
+++ b/src/main/java/es/upm/miw/apaw/domain/services/theater/TheaterArtistService.java
@@ -1,0 +1,25 @@
+package es.upm.miw.apaw.domain.services.theater;
+
+import es.upm.miw.apaw.domain.exceptions.ConflictException;
+import es.upm.miw.apaw.domain.models.theater.TheaterArtist;
+import es.upm.miw.apaw.domain.persistenceports.theater.TheaterArtistPersistence;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TheaterArtistService {
+
+    private final TheaterArtistPersistence theaterArtistPersistence;
+
+    @Autowired
+    public TheaterArtistService(TheaterArtistPersistence theaterArtistPersistence) {
+        this.theaterArtistPersistence = theaterArtistPersistence;
+    }
+
+    public TheaterArtist create(TheaterArtist theaterArtist) {
+        if (this.theaterArtistPersistence.existsByArtistCode(theaterArtist.getArtistCode())) {
+            throw new ConflictException("TheaterArtist artistCode: " + theaterArtist.getArtistCode());
+        }
+        return this.theaterArtistPersistence.create(theaterArtist);
+    }
+}

--- a/src/test/java/es/upm/miw/apaw/domain/services/theater/TheaterArtistServiceTest.java
+++ b/src/test/java/es/upm/miw/apaw/domain/services/theater/TheaterArtistServiceTest.java
@@ -1,0 +1,69 @@
+package es.upm.miw.apaw.domain.services.theater;
+
+import es.upm.miw.apaw.domain.exceptions.ConflictException;
+import es.upm.miw.apaw.domain.models.theater.TheaterArtist;
+import es.upm.miw.apaw.domain.persistenceports.theater.TheaterArtistPersistence;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class TheaterArtistServiceTest {
+
+    @Autowired
+    private TheaterArtistService theaterArtistService;
+
+    @MockitoBean
+    private TheaterArtistPersistence theaterArtistPersistence;
+
+    @Test
+    void testCreate() {
+        BDDMockito.given(this.theaterArtistPersistence.existsByArtistCode("TART99"))
+                .willReturn(false);
+        BDDMockito.given(this.theaterArtistPersistence.create(Mockito.any(TheaterArtist.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        TheaterArtist artist = TheaterArtist.builder()
+                .artistCode("TART99")
+                .artistFullName("Test Artist")
+                .artistBirthDate(LocalDate.of(1990, 1, 1))
+                .artistFee(new BigDecimal("500.00"))
+                .artistActive(true)
+                .build();
+
+        TheaterArtist result = this.theaterArtistService.create(artist);
+
+        assertThat(result.getArtistCode()).isEqualTo("TART99");
+        assertThat(result.getArtistFullName()).isEqualTo("Test Artist");
+        BDDMockito.then(this.theaterArtistPersistence).should().create(artist);
+    }
+
+    @Test
+    void testCreate_ConflictException() {
+        BDDMockito.given(this.theaterArtistPersistence.existsByArtistCode("TART99"))
+                .willReturn(true);
+
+        TheaterArtist artist = TheaterArtist.builder()
+                .artistCode("TART99")
+                .artistFullName("Duplicate Artist")
+                .artistBirthDate(LocalDate.of(1990, 1, 1))
+                .artistFee(new BigDecimal("500.00"))
+                .artistActive(true)
+                .build();
+
+        assertThatThrownBy(() -> this.theaterArtistService.create(artist))
+                .isInstanceOf(ConflictException.class)
+                .hasMessageContaining("TART99");
+    }
+}

--- a/src/test/java/es/upm/miw/apaw/functionaltests/theater/TheaterArtistResourceFT.java
+++ b/src/test/java/es/upm/miw/apaw/functionaltests/theater/TheaterArtistResourceFT.java
@@ -1,0 +1,88 @@
+package es.upm.miw.apaw.functionaltests.theater;
+
+import es.upm.miw.apaw.BaseTheaterTests;
+import es.upm.miw.apaw.adapters.resources.theater.TheaterArtistResource;
+import es.upm.miw.apaw.domain.models.theater.TheaterArtist;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@ActiveProfiles("test")
+class TheaterArtistResourceFT extends BaseTheaterTests {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Test
+    void testCreate() {
+        TheaterArtist artist = TheaterArtist.builder()
+                .artistCode("TART99")
+                .artistFullName("Test Artist")
+                .artistBirthDate(LocalDate.of(1990, 1, 1))
+                .artistFee(new BigDecimal("500.00"))
+                .artistActive(true)
+                .build();
+
+        webTestClient.post()
+                .uri(TheaterArtistResource.ARTISTS)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(artist)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(TheaterArtist.class)
+                .value(created -> {
+                    assert created != null;
+                    assert created.getArtistCode().equals("TART99");
+                    assert created.getArtistFullName().equals("Test Artist");
+                    assert created.getArtistBirthDate().equals(LocalDate.of(1990, 1, 1));
+                    assert created.getArtistFee().equals(new BigDecimal("500.00"));
+                    assert created.getArtistActive();
+                });
+    }
+
+    @Test
+    void testCreate_Conflict() {
+        TheaterArtist artist = TheaterArtist.builder()
+                .artistCode("TART01")
+                .artistFullName("Duplicate Artist")
+                .artistBirthDate(LocalDate.of(1990, 1, 1))
+                .artistFee(new BigDecimal("500.00"))
+                .artistActive(true)
+                .build();
+
+        webTestClient.post()
+                .uri(TheaterArtistResource.ARTISTS)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(artist)
+                .exchange()
+                .expectStatus().isEqualTo(HttpStatus.CONFLICT);
+    }
+
+    @Test
+    void testCreate_BadRequest() {
+        TheaterArtist artist = TheaterArtist.builder()
+                .artistCode(null)
+                .artistFullName("No Code Artist")
+                .artistBirthDate(LocalDate.of(1990, 1, 1))
+                .artistFee(new BigDecimal("500.00"))
+                .artistActive(true)
+                .build();
+
+        webTestClient.post()
+                .uri(TheaterArtistResource.ARTISTS)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(artist)
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements the second REST endpoint for `story:theater`.

Endpoint:

POST `/theater/artists`

## Changes

- Add `TheaterArtistService`.
- Add `TheaterArtistResource`.
- Add service tests for `TheaterArtistService`.
- Add functional tests for `POST /theater/artists`.

## Scope

This PR only implements the POST endpoint for Theater artists.

Out of scope:
- No GET artist endpoint.
- No PUT endpoint.
- No DELETE endpoint.
- No PATCH endpoint.
- No search endpoints.
- No changes to Theater domain model.
- No changes to Theater persistence behavior.
- No new delete method.
- No changes to unrelated stories.

## Validation

Validated by Cursor:
- `mvn -q -DskipTests compile`
- `mvn -q "-Dtest=*Theater*" test`
- `mvn -q test`

All commands passed.

Additional pre-commit checks:
- Only 4 new files staged.
- No model, persistence, pom.xml, workflow, Docker, or unrelated files staged.
- No forbidden reverse relationship fields restored.

## Notes

Related issue: #1384

Theater model issue #1374 and persistence issue #1380 remain open while waiting for teacher confirmation, but their code has already been merged into `develop`.