### PR TITLE
Add theater PUT hall endpoint #1386

### DIFF
--- a/src/main/java/es/upm/miw/apaw/adapters/resources/theater/TheaterHallResource.java
+++ b/src/main/java/es/upm/miw/apaw/adapters/resources/theater/TheaterHallResource.java
@@ -1,0 +1,31 @@
+package es.upm.miw.apaw.adapters.resources.theater;
+
+import es.upm.miw.apaw.domain.models.theater.TheaterHall;
+import es.upm.miw.apaw.domain.services.theater.TheaterHallService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(TheaterHallResource.HALLS)
+public class TheaterHallResource {
+
+    public static final String HALLS = "/theater/halls";
+    public static final String HALL_CODE = "/{hallCode}";
+
+    private final TheaterHallService theaterHallService;
+
+    @Autowired
+    public TheaterHallResource(TheaterHallService theaterHallService) {
+        this.theaterHallService = theaterHallService;
+    }
+
+    @PutMapping(HALL_CODE)
+    public TheaterHall update(@PathVariable String hallCode, @Valid @RequestBody TheaterHall theaterHall) {
+        return this.theaterHallService.update(hallCode, theaterHall);
+    }
+}

--- a/src/main/java/es/upm/miw/apaw/domain/services/theater/TheaterHallService.java
+++ b/src/main/java/es/upm/miw/apaw/domain/services/theater/TheaterHallService.java
@@ -1,0 +1,21 @@
+package es.upm.miw.apaw.domain.services.theater;
+
+import es.upm.miw.apaw.domain.models.theater.TheaterHall;
+import es.upm.miw.apaw.domain.persistenceports.theater.TheaterHallPersistence;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TheaterHallService {
+
+    private final TheaterHallPersistence theaterHallPersistence;
+
+    @Autowired
+    public TheaterHallService(TheaterHallPersistence theaterHallPersistence) {
+        this.theaterHallPersistence = theaterHallPersistence;
+    }
+
+    public TheaterHall update(String hallCode, TheaterHall theaterHall) {
+        return this.theaterHallPersistence.update(hallCode, theaterHall);
+    }
+}

--- a/src/test/java/es/upm/miw/apaw/domain/services/theater/TheaterHallServiceTest.java
+++ b/src/test/java/es/upm/miw/apaw/domain/services/theater/TheaterHallServiceTest.java
@@ -1,0 +1,61 @@
+package es.upm.miw.apaw.domain.services.theater;
+
+import es.upm.miw.apaw.domain.exceptions.NotFoundException;
+import es.upm.miw.apaw.domain.models.theater.TheaterHall;
+import es.upm.miw.apaw.domain.persistenceports.theater.TheaterHallPersistence;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class TheaterHallServiceTest {
+
+    @Autowired
+    private TheaterHallService theaterHallService;
+
+    @MockitoBean
+    private TheaterHallPersistence theaterHallPersistence;
+
+    @Test
+    void testUpdate() {
+        TheaterHall hall = TheaterHall.builder()
+                .hallCode("THAL01")
+                .hallName("Updated Hall")
+                .hallCapacity(400)
+                .hallAccessible(true)
+                .build();
+        BDDMockito.given(this.theaterHallPersistence.update(Mockito.eq("THAL01"), Mockito.any(TheaterHall.class)))
+                .willAnswer(invocation -> invocation.getArgument(1));
+
+        TheaterHall result = this.theaterHallService.update("THAL01", hall);
+
+        assertThat(result.getHallName()).isEqualTo("Updated Hall");
+        assertThat(result.getHallCapacity()).isEqualTo(400);
+        BDDMockito.then(this.theaterHallPersistence).should().update(Mockito.eq("THAL01"), Mockito.any(TheaterHall.class));
+    }
+
+    @Test
+    void testUpdate_NotFound() {
+        BDDMockito.given(this.theaterHallPersistence.update(Mockito.eq("NONEXISTENT"), Mockito.any(TheaterHall.class)))
+                .willThrow(new NotFoundException("TheaterHall hallCode: NONEXISTENT"));
+
+        TheaterHall hall = TheaterHall.builder()
+                .hallCode("NONEXISTENT")
+                .hallName("No Hall")
+                .hallCapacity(0)
+                .hallAccessible(false)
+                .build();
+
+        assertThatThrownBy(() -> this.theaterHallService.update("NONEXISTENT", hall))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("NONEXISTENT");
+    }
+}

--- a/src/test/java/es/upm/miw/apaw/functionaltests/theater/TheaterHallResourceFT.java
+++ b/src/test/java/es/upm/miw/apaw/functionaltests/theater/TheaterHallResourceFT.java
@@ -1,0 +1,82 @@
+package es.upm.miw.apaw.functionaltests.theater;
+
+import es.upm.miw.apaw.BaseTheaterTests;
+import es.upm.miw.apaw.adapters.resources.theater.TheaterHallResource;
+import es.upm.miw.apaw.domain.models.theater.TheaterHall;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@ActiveProfiles("test")
+class TheaterHallResourceFT extends BaseTheaterTests {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Test
+    void testUpdate() {
+        TheaterHall hall = TheaterHall.builder()
+                .hallCode("THAL01")
+                .hallName("Updated Theater Hall A")
+                .hallCapacity(350)
+                .hallAccessible(true)
+                .build();
+
+        webTestClient.put()
+                .uri(TheaterHallResource.HALLS + TheaterHallResource.HALL_CODE, "THAL01")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(hall)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(TheaterHall.class)
+                .value(updated -> {
+                    assertThat(updated).isNotNull();
+                    assertThat(updated.getHallCode()).isEqualTo("THAL01");
+                    assertThat(updated.getHallName()).isEqualTo("Updated Theater Hall A");
+                    assertThat(updated.getHallCapacity()).isEqualTo(350);
+                    assertThat(updated.getHallAccessible()).isTrue();
+                });
+    }
+
+    @Test
+    void testUpdate_NotFound() {
+        TheaterHall hall = TheaterHall.builder()
+                .hallCode("NONEXISTENT")
+                .hallName("No Hall")
+                .hallCapacity(0)
+                .hallAccessible(false)
+                .build();
+
+        webTestClient.put()
+                .uri(TheaterHallResource.HALLS + TheaterHallResource.HALL_CODE, "NONEXISTENT")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(hall)
+                .exchange()
+                .expectStatus().isNotFound();
+    }
+
+    @Test
+    void testUpdate_BadRequest() {
+        TheaterHall hall = TheaterHall.builder()
+                .hallCode("THAL01")
+                .hallName(null)
+                .hallCapacity(-1)
+                .hallAccessible(true)
+                .build();
+
+        webTestClient.put()
+                .uri(TheaterHallResource.HALLS + TheaterHallResource.HALL_CODE, "THAL01")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(hall)
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements the third REST endpoint for `story:theater`.

Endpoint:

PUT `/theater/halls/{hallCode}`

## Changes

- Add `TheaterHallService`.
- Add `TheaterHallResource`.
- Add service tests for `TheaterHallService`.
- Add functional tests for `PUT /theater/halls/{hallCode}`.

## Scope

This PR only implements the PUT endpoint for Theater halls.

Out of scope:
- No GET hall endpoint.
- No POST hall endpoint.
- No DELETE endpoint.
- No PATCH endpoint.
- No search endpoints.
- No changes to Theater domain model.
- No changes to Theater persistence behavior.
- No new persistence methods.
- No changes to unrelated stories.

## Validation

Validated by Cursor:
- `mvn -q -DskipTests compile`
- `mvn -q "-Dtest=*Theater*" test`
- `mvn -q test`

All commands passed.

Additional pre-commit checks:
- Only 4 new files staged.
- No model, persistence, pom.xml, workflow, Docker, or unrelated files staged.
- No forbidden reverse relationship fields restored.

## Notes

Related issue: #1386

Theater model issue #1374 and persistence issue #1380 remain open while waiting for teacher confirmation, but their code has already been merged into `develop`.