### PR TITLE
Add theater DELETE artist endpoint #1388

### DIFF
--- a/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterArtistPersistenceMongodb.java
+++ b/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterArtistPersistenceMongodb.java
@@ -50,4 +50,12 @@ public class TheaterArtistPersistenceMongodb implements TheaterArtistPersistence
     public boolean existsByArtistCode(String artistCode) {
         return this.theaterArtistRepository.findByArtistCode(artistCode).isPresent();
     }
+
+    @Override
+    public void delete(String artistCode) {
+        int deleted = this.theaterArtistRepository.deleteByArtistCode(artistCode);
+        if (deleted == 0) {
+            throw new NotFoundException("TheaterArtist artistCode: " + artistCode);
+        }
+    }
 }

--- a/src/main/java/es/upm/miw/apaw/adapters/resources/theater/TheaterArtistResource.java
+++ b/src/main/java/es/upm/miw/apaw/adapters/resources/theater/TheaterArtistResource.java
@@ -4,9 +4,13 @@ import es.upm.miw.apaw.domain.models.theater.TheaterArtist;
 import es.upm.miw.apaw.domain.services.theater.TheaterArtistService;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -14,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class TheaterArtistResource {
 
     public static final String ARTISTS = "/theater/artists";
+    public static final String ARTIST_CODE = "/{artistCode}";
 
     private final TheaterArtistService theaterArtistService;
 
@@ -25,5 +30,11 @@ public class TheaterArtistResource {
     @PostMapping
     public TheaterArtist create(@Valid @RequestBody TheaterArtist theaterArtist) {
         return this.theaterArtistService.create(theaterArtist);
+    }
+
+    @DeleteMapping(TheaterArtistResource.ARTIST_CODE)
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable String artistCode) {
+        this.theaterArtistService.delete(artistCode);
     }
 }

--- a/src/main/java/es/upm/miw/apaw/domain/persistenceports/theater/TheaterArtistPersistence.java
+++ b/src/main/java/es/upm/miw/apaw/domain/persistenceports/theater/TheaterArtistPersistence.java
@@ -17,4 +17,6 @@ public interface TheaterArtistPersistence {
     Stream<TheaterArtist> readAll();
 
     boolean existsByArtistCode(String artistCode);
+
+    void delete(String artistCode);
 }

--- a/src/main/java/es/upm/miw/apaw/domain/services/theater/TheaterArtistService.java
+++ b/src/main/java/es/upm/miw/apaw/domain/services/theater/TheaterArtistService.java
@@ -22,4 +22,8 @@ public class TheaterArtistService {
         }
         return this.theaterArtistPersistence.create(theaterArtist);
     }
+
+    public void delete(String artistCode) {
+        this.theaterArtistPersistence.delete(artistCode);
+    }
 }

--- a/src/test/java/es/upm/miw/apaw/domain/services/theater/TheaterArtistServiceTest.java
+++ b/src/test/java/es/upm/miw/apaw/domain/services/theater/TheaterArtistServiceTest.java
@@ -1,6 +1,7 @@
 package es.upm.miw.apaw.domain.services.theater;
 
 import es.upm.miw.apaw.domain.exceptions.ConflictException;
+import es.upm.miw.apaw.domain.exceptions.NotFoundException;
 import es.upm.miw.apaw.domain.models.theater.TheaterArtist;
 import es.upm.miw.apaw.domain.persistenceports.theater.TheaterArtistPersistence;
 import org.junit.jupiter.api.Test;
@@ -65,5 +66,21 @@ class TheaterArtistServiceTest {
         assertThatThrownBy(() -> this.theaterArtistService.create(artist))
                 .isInstanceOf(ConflictException.class)
                 .hasMessageContaining("TART99");
+    }
+
+    @Test
+    void testDelete() {
+        this.theaterArtistService.delete("TART01");
+        BDDMockito.then(this.theaterArtistPersistence).should().delete("TART01");
+    }
+
+    @Test
+    void testDelete_NotFound() {
+        BDDMockito.doThrow(new NotFoundException("TheaterArtist artistCode: NONEXISTENT"))
+                .when(this.theaterArtistPersistence).delete("NONEXISTENT");
+
+        assertThatThrownBy(() -> this.theaterArtistService.delete("NONEXISTENT"))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("NONEXISTENT");
     }
 }

--- a/src/test/java/es/upm/miw/apaw/functionaltests/theater/TheaterArtistResourceFT.java
+++ b/src/test/java/es/upm/miw/apaw/functionaltests/theater/TheaterArtistResourceFT.java
@@ -15,6 +15,8 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureWebTestClient
 @ActiveProfiles("test")
@@ -84,5 +86,21 @@ class TheaterArtistResourceFT extends BaseTheaterTests {
                 .bodyValue(artist)
                 .exchange()
                 .expectStatus().isBadRequest();
+    }
+
+    @Test
+    void testDelete() {
+        webTestClient.delete()
+                .uri(TheaterArtistResource.ARTISTS + TheaterArtistResource.ARTIST_CODE, "TART01")
+                .exchange()
+                .expectStatus().isNoContent();
+    }
+
+    @Test
+    void testDelete_NotFound() {
+        webTestClient.delete()
+                .uri(TheaterArtistResource.ARTISTS + TheaterArtistResource.ARTIST_CODE, "NONEXISTENT")
+                .exchange()
+                .expectStatus().isNotFound();
     }
 }


### PR DESCRIPTION
## Summary

This PR implements the fourth REST endpoint for `story:theater`.

Endpoint:

DELETE `/theater/artists/{artistCode}`

## Changes

- Add `delete(String artistCode)` to `TheaterArtistPersistence`.
- Implement delete support in `TheaterArtistPersistenceMongodb`.
- Add DELETE support to `TheaterArtistService`.
- Add DELETE endpoint to `TheaterArtistResource`.
- Add service tests for artist delete.
- Add functional tests for `DELETE /theater/artists/{artistCode}`.

## Scope

This PR only implements the DELETE endpoint for Theater artists.

Out of scope:
- No GET artist endpoint.
- No PUT artist endpoint.
- No PATCH endpoint.
- No search endpoints.
- No changes to Theater domain model.
- No changes to Theater unidirectional relationships.
- No changes to unrelated stories.

## Validation

Validated by Cursor:
- `mvn -q -DskipTests compile`
- `mvn -q "-Dtest=*Theater*" test`
- `mvn -q test`

All commands passed.

Additional pre-commit checks:
- Only 6 expected files staged.
- No Theater domain model, pom.xml, workflow, Docker, or unrelated files staged.
- No forbidden reverse relationship fields restored.

## Notes

Related issue: #1388

Theater model issue #1374 and persistence issue #1380 remain open while waiting for teacher confirmation, but their code has already been merged into `develop`.