### PR TITLE
Add theater PATCH artist active endpoint #1390

### DIFF
--- a/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/entities/TheaterArtistEntity.java
+++ b/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/entities/TheaterArtistEntity.java
@@ -44,4 +44,8 @@ public class TheaterArtistEntity {
         BeanUtils.copyProperties(this, theaterArtist);
         return theaterArtist;
     }
+
+    public void patchActive(Boolean artistActive) {
+        this.artistActive = artistActive;
+    }
 }

--- a/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterArtistPersistenceMongodb.java
+++ b/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterArtistPersistenceMongodb.java
@@ -58,4 +58,12 @@ public class TheaterArtistPersistenceMongodb implements TheaterArtistPersistence
             throw new NotFoundException("TheaterArtist artistCode: " + artistCode);
         }
     }
+
+    @Override
+    public TheaterArtist patchActive(String artistCode, Boolean artistActive) {
+        TheaterArtistEntity entity = this.theaterArtistRepository.findByArtistCode(artistCode)
+                .orElseThrow(() -> new NotFoundException("TheaterArtist artistCode: " + artistCode));
+        entity.patchActive(artistActive);
+        return this.theaterArtistRepository.save(entity).toTheaterArtist();
+    }
 }

--- a/src/main/java/es/upm/miw/apaw/adapters/resources/theater/TheaterArtistResource.java
+++ b/src/main/java/es/upm/miw/apaw/adapters/resources/theater/TheaterArtistResource.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,6 +20,9 @@ public class TheaterArtistResource {
 
     public static final String ARTISTS = "/theater/artists";
     public static final String ARTIST_CODE = "/{artistCode}";
+    public static final String ACTIVE = "/active";
+
+    public record PatchActiveDto(Boolean artistActive) {}
 
     private final TheaterArtistService theaterArtistService;
 
@@ -36,5 +40,11 @@ public class TheaterArtistResource {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable String artistCode) {
         this.theaterArtistService.delete(artistCode);
+    }
+
+    @PatchMapping(TheaterArtistResource.ARTIST_CODE + ACTIVE)
+    public TheaterArtist patchActive(@PathVariable String artistCode,
+            @Valid @RequestBody PatchActiveDto patchActiveDto) {
+        return this.theaterArtistService.patchActive(artistCode, patchActiveDto.artistActive());
     }
 }

--- a/src/main/java/es/upm/miw/apaw/domain/persistenceports/theater/TheaterArtistPersistence.java
+++ b/src/main/java/es/upm/miw/apaw/domain/persistenceports/theater/TheaterArtistPersistence.java
@@ -19,4 +19,6 @@ public interface TheaterArtistPersistence {
     boolean existsByArtistCode(String artistCode);
 
     void delete(String artistCode);
+
+    TheaterArtist patchActive(String artistCode, Boolean artistActive);
 }

--- a/src/main/java/es/upm/miw/apaw/domain/services/theater/TheaterArtistService.java
+++ b/src/main/java/es/upm/miw/apaw/domain/services/theater/TheaterArtistService.java
@@ -26,4 +26,8 @@ public class TheaterArtistService {
     public void delete(String artistCode) {
         this.theaterArtistPersistence.delete(artistCode);
     }
+
+    public TheaterArtist patchActive(String artistCode, Boolean artistActive) {
+        return this.theaterArtistPersistence.patchActive(artistCode, artistActive);
+    }
 }

--- a/src/test/java/es/upm/miw/apaw/domain/services/theater/TheaterArtistServiceTest.java
+++ b/src/test/java/es/upm/miw/apaw/domain/services/theater/TheaterArtistServiceTest.java
@@ -83,4 +83,32 @@ class TheaterArtistServiceTest {
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("NONEXISTENT");
     }
+
+    @Test
+    void testPatchActive() {
+        TheaterArtist artist = TheaterArtist.builder()
+                .artistCode("TART01")
+                .artistFullName("Alice Performer")
+                .artistBirthDate(LocalDate.of(1992, 4, 10))
+                .artistFee(new BigDecimal("800.00"))
+                .artistActive(false)
+                .build();
+        BDDMockito.given(this.theaterArtistPersistence.patchActive(Mockito.eq("TART01"), Mockito.eq(false)))
+                .willReturn(artist);
+
+        TheaterArtist result = this.theaterArtistService.patchActive("TART01", false);
+
+        assertThat(result.getArtistActive()).isFalse();
+        BDDMockito.then(this.theaterArtistPersistence).should().patchActive(Mockito.eq("TART01"), Mockito.eq(false));
+    }
+
+    @Test
+    void testPatchActive_NotFound() {
+        BDDMockito.given(this.theaterArtistPersistence.patchActive(Mockito.eq("NONEXISTENT"), Mockito.any(Boolean.class)))
+                .willThrow(new NotFoundException("TheaterArtist artistCode: NONEXISTENT"));
+
+        assertThatThrownBy(() -> this.theaterArtistService.patchActive("NONEXISTENT", true))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("NONEXISTENT");
+    }
 }

--- a/src/test/java/es/upm/miw/apaw/functionaltests/theater/TheaterArtistResourceFT.java
+++ b/src/test/java/es/upm/miw/apaw/functionaltests/theater/TheaterArtistResourceFT.java
@@ -2,6 +2,7 @@ package es.upm.miw.apaw.functionaltests.theater;
 
 import es.upm.miw.apaw.BaseTheaterTests;
 import es.upm.miw.apaw.adapters.resources.theater.TheaterArtistResource;
+import es.upm.miw.apaw.adapters.resources.theater.TheaterArtistResource.PatchActiveDto;
 import es.upm.miw.apaw.domain.models.theater.TheaterArtist;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -100,6 +101,37 @@ class TheaterArtistResourceFT extends BaseTheaterTests {
     void testDelete_NotFound() {
         webTestClient.delete()
                 .uri(TheaterArtistResource.ARTISTS + TheaterArtistResource.ARTIST_CODE, "NONEXISTENT")
+                .exchange()
+                .expectStatus().isNotFound();
+    }
+
+    @Test
+    void testPatchActive() {
+        PatchActiveDto dto = new PatchActiveDto(false);
+
+        webTestClient.patch()
+                .uri(TheaterArtistResource.ARTISTS + TheaterArtistResource.ARTIST_CODE + TheaterArtistResource.ACTIVE, "TART01")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(dto)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(TheaterArtist.class)
+                .value(updated -> {
+                    assertThat(updated).isNotNull();
+                    assertThat(updated.getArtistCode()).isEqualTo("TART01");
+                    assertThat(updated.getArtistFullName()).isEqualTo("Alice Performer");
+                    assertThat(updated.getArtistActive()).isFalse();
+                });
+    }
+
+    @Test
+    void testPatchActive_NotFound() {
+        PatchActiveDto dto = new PatchActiveDto(true);
+
+        webTestClient.patch()
+                .uri(TheaterArtistResource.ARTISTS + TheaterArtistResource.ARTIST_CODE + TheaterArtistResource.ACTIVE, "NONEXISTENT")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(dto)
                 .exchange()
                 .expectStatus().isNotFound();
     }


### PR DESCRIPTION
## Summary

This PR implements the fifth REST endpoint for `story:theater`.

Endpoint:

PATCH `/theater/artists/{artistCode}/active`

## Changes

- Add `patchActive(String artistCode, Boolean artistActive)` to `TheaterArtistPersistence`.
- Add minimal `patchActive(Boolean artistActive)` support to `TheaterArtistEntity`.
- Implement PATCH active support in `TheaterArtistPersistenceMongodb`.
- Add PATCH active support to `TheaterArtistService`.
- Add PATCH active endpoint to `TheaterArtistResource`.
- Add service tests for artist active patch.
- Add functional tests for `PATCH /theater/artists/{artistCode}/active`.

## Scope

This PR only implements the PATCH endpoint for Theater artist active status.

Out of scope:
- No GET artist endpoint.
- No POST changes.
- No PUT changes.
- No DELETE changes.
- No search endpoints.
- No changes to Theater domain model.
- No changes to Theater unidirectional relationships.
- No changes to TheaterPerformance or any performanceSoldOut field.
- No changes to unrelated stories.

## Validation

Validated by Cursor:
- `mvn -q -DskipTests compile`
- `mvn -q "-Dtest=*Theater*" test`
- `mvn -q test`

All commands passed.

Additional pre-commit checks:
- Only 7 expected files staged.
- No Theater domain model, pom.xml, workflow, Docker, or unrelated files staged.
- No forbidden reverse relationship fields restored.

## Notes

Related issue: #1390

This is endpoint 5 of the required 5 endpoints for `story:theater`.

Theater model issue #1374 and persistence issue #1380 remain open while waiting for teacher confirmation, but their code has already been merged into `develop`.