### PR TITLE
Add theater performance date search #1392

### DIFF
--- a/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterPerformancePersistenceMongodb.java
+++ b/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterPerformancePersistenceMongodb.java
@@ -12,8 +12,12 @@ import es.upm.miw.apaw.domain.models.theater.TheaterHall;
 import es.upm.miw.apaw.domain.models.theater.TheaterPerformance;
 import es.upm.miw.apaw.domain.persistenceports.theater.TheaterPerformancePersistence;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -25,15 +29,18 @@ public class TheaterPerformancePersistenceMongodb implements TheaterPerformanceP
     private final TheaterPerformanceRepository theaterPerformanceRepository;
     private final TheaterHallRepository theaterHallRepository;
     private final TheaterArtistRepository theaterArtistRepository;
+    private final MongoTemplate mongoTemplate;
 
     @Autowired
     public TheaterPerformancePersistenceMongodb(
             TheaterPerformanceRepository theaterPerformanceRepository,
             TheaterHallRepository theaterHallRepository,
-            TheaterArtistRepository theaterArtistRepository) {
+            TheaterArtistRepository theaterArtistRepository,
+            MongoTemplate mongoTemplate) {
         this.theaterPerformanceRepository = theaterPerformanceRepository;
         this.theaterHallRepository = theaterHallRepository;
         this.theaterArtistRepository = theaterArtistRepository;
+        this.mongoTemplate = mongoTemplate;
     }
 
     @Override
@@ -109,5 +116,13 @@ public class TheaterPerformancePersistenceMongodb implements TheaterPerformanceP
                 .getPerformanceArtists()
                 .stream()
                 .map(TheaterArtistEntity::toTheaterArtist);
+    }
+
+    @Override
+    public Stream<TheaterPerformance> findByMinDate(LocalDate minDate) {
+        Query query = new Query(Criteria.where("performanceDate").gte(minDate));
+        return this.mongoTemplate.find(query, TheaterPerformanceEntity.class)
+                .stream()
+                .map(TheaterPerformanceEntity::toTheaterPerformance);
     }
 }

--- a/src/main/java/es/upm/miw/apaw/adapters/resources/theater/TheaterPerformanceResource.java
+++ b/src/main/java/es/upm/miw/apaw/adapters/resources/theater/TheaterPerformanceResource.java
@@ -1,0 +1,32 @@
+package es.upm.miw.apaw.adapters.resources.theater;
+
+import es.upm.miw.apaw.domain.models.theater.TheaterPerformance;
+import es.upm.miw.apaw.domain.services.theater.TheaterPerformanceService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.stream.Stream;
+
+@RestController
+@RequestMapping(TheaterPerformanceResource.PERFORMANCES)
+public class TheaterPerformanceResource {
+
+    public static final String PERFORMANCES = "/theater/performances";
+    public static final String SEARCH = "/search";
+
+    private final TheaterPerformanceService theaterPerformanceService;
+
+    @Autowired
+    public TheaterPerformanceResource(TheaterPerformanceService theaterPerformanceService) {
+        this.theaterPerformanceService = theaterPerformanceService;
+    }
+
+    @GetMapping(SEARCH)
+    public Stream<TheaterPerformance> findByMinDate(@RequestParam LocalDate minDate) {
+        return this.theaterPerformanceService.findByMinDate(minDate);
+    }
+}

--- a/src/main/java/es/upm/miw/apaw/domain/persistenceports/theater/TheaterPerformancePersistence.java
+++ b/src/main/java/es/upm/miw/apaw/domain/persistenceports/theater/TheaterPerformancePersistence.java
@@ -4,6 +4,7 @@ import es.upm.miw.apaw.domain.models.theater.TheaterArtist;
 import es.upm.miw.apaw.domain.models.theater.TheaterPerformance;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.stream.Stream;
 
 @Repository
@@ -20,4 +21,6 @@ public interface TheaterPerformancePersistence {
     boolean existsByPerformanceCode(String performanceCode);
 
     Stream<TheaterArtist> findArtistsByPerformanceCode(String performanceCode);
+
+    Stream<TheaterPerformance> findByMinDate(LocalDate minDate);
 }

--- a/src/main/java/es/upm/miw/apaw/domain/services/theater/TheaterPerformanceService.java
+++ b/src/main/java/es/upm/miw/apaw/domain/services/theater/TheaterPerformanceService.java
@@ -1,0 +1,24 @@
+package es.upm.miw.apaw.domain.services.theater;
+
+import es.upm.miw.apaw.domain.models.theater.TheaterPerformance;
+import es.upm.miw.apaw.domain.persistenceports.theater.TheaterPerformancePersistence;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.stream.Stream;
+
+@Service
+public class TheaterPerformanceService {
+
+    private final TheaterPerformancePersistence theaterPerformancePersistence;
+
+    @Autowired
+    public TheaterPerformanceService(TheaterPerformancePersistence theaterPerformancePersistence) {
+        this.theaterPerformancePersistence = theaterPerformancePersistence;
+    }
+
+    public Stream<TheaterPerformance> findByMinDate(LocalDate minDate) {
+        return this.theaterPerformancePersistence.findByMinDate(minDate);
+    }
+}

--- a/src/test/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterPerformancePersistenceMongodbIT.java
+++ b/src/test/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterPerformancePersistenceMongodbIT.java
@@ -124,6 +124,30 @@ class TheaterPerformancePersistenceMongodbIT extends BaseTheaterTests {
     }
 
     @Test
+    void testFindByMinDate() {
+        LocalDate minDate = LocalDate.of(2026, 11, 1);
+        var results = theaterPerformancePersistenceMongodb.findByMinDate(minDate).toList();
+        assertThat(results).hasSize(1);
+        assertThat(results.getFirst().getPerformanceCode()).isEqualTo("TPER01");
+        assertThat(results.getFirst().getPerformanceDate()).isEqualTo(LocalDate.of(2026, 12, 1));
+    }
+
+    @Test
+    void testFindByMinDate_NoResults() {
+        LocalDate minDate = LocalDate.of(2027, 1, 1);
+        var results = theaterPerformancePersistenceMongodb.findByMinDate(minDate).toList();
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    void testFindByMinDate_AllPerformances() {
+        LocalDate minDate = LocalDate.of(2026, 1, 1);
+        var results = theaterPerformancePersistenceMongodb.findByMinDate(minDate).toList();
+        assertThat(results).hasSize(1);
+        assertThat(results.getFirst().getPerformanceCode()).isEqualTo("TPER01");
+    }
+
+    @Test
     void testPerformanceToHallUnidirectionalRelationship() {
         TheaterPerformance read = theaterPerformancePersistenceMongodb.read(performances[0].getPerformanceCode());
         TheaterHall hall = read.getPerformanceHall();

--- a/src/test/java/es/upm/miw/apaw/domain/services/theater/TheaterPerformanceServiceTest.java
+++ b/src/test/java/es/upm/miw/apaw/domain/services/theater/TheaterPerformanceServiceTest.java
@@ -1,0 +1,61 @@
+package es.upm.miw.apaw.domain.services.theater;
+
+import es.upm.miw.apaw.domain.models.theater.TheaterPerformance;
+import es.upm.miw.apaw.domain.persistenceports.theater.TheaterPerformancePersistence;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class TheaterPerformanceServiceTest {
+
+    @Autowired
+    private TheaterPerformanceService theaterPerformanceService;
+
+    @MockitoBean
+    private TheaterPerformancePersistence theaterPerformancePersistence;
+
+    @Test
+    void testFindByMinDate() {
+        TheaterPerformance perf = TheaterPerformance.builder()
+                .performanceCode("TPER01")
+                .performanceTitle("Test Play")
+                .performanceDate(LocalDate.of(2026, 12, 1))
+                .performanceDurationMinutes(90)
+                .performanceTicketPrice(new BigDecimal("25.00"))
+                .build();
+        BDDMockito.given(this.theaterPerformancePersistence.findByMinDate(Mockito.eq(LocalDate.of(2026, 11, 1))))
+                .willReturn(Stream.of(perf));
+
+        Stream<TheaterPerformance> result = this.theaterPerformanceService.findByMinDate(LocalDate.of(2026, 11, 1));
+        List<TheaterPerformance> list = result.toList();
+
+        assertThat(list).hasSize(1);
+        assertThat(list.getFirst().getPerformanceCode()).isEqualTo("TPER01");
+        assertThat(list.getFirst().getPerformanceDate()).isEqualTo(LocalDate.of(2026, 12, 1));
+        BDDMockito.then(this.theaterPerformancePersistence).should().findByMinDate(LocalDate.of(2026, 11, 1));
+    }
+
+    @Test
+    void testFindByMinDate_NoResults() {
+        BDDMockito.given(this.theaterPerformancePersistence.findByMinDate(Mockito.any(LocalDate.class)))
+                .willReturn(Stream.empty());
+
+        Stream<TheaterPerformance> result = this.theaterPerformanceService.findByMinDate(LocalDate.of(2027, 1, 1));
+        List<TheaterPerformance> list = result.toList();
+
+        assertThat(list).isEmpty();
+    }
+}

--- a/src/test/java/es/upm/miw/apaw/functionaltests/theater/TheaterPerformanceResourceFT.java
+++ b/src/test/java/es/upm/miw/apaw/functionaltests/theater/TheaterPerformanceResourceFT.java
@@ -1,0 +1,62 @@
+package es.upm.miw.apaw.functionaltests.theater;
+
+import es.upm.miw.apaw.BaseTheaterTests;
+import es.upm.miw.apaw.adapters.resources.theater.TheaterPerformanceResource;
+import es.upm.miw.apaw.domain.models.theater.TheaterPerformance;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@ActiveProfiles("test")
+class TheaterPerformanceResourceFT extends BaseTheaterTests {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Test
+    void testFindByMinDate() {
+        webTestClient.get()
+                .uri(TheaterPerformanceResource.PERFORMANCES + TheaterPerformanceResource.SEARCH + "?minDate=2026-11-01")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBodyList(TheaterPerformance.class)
+                .value(performances -> {
+                    assertThat(performances).hasSize(1);
+                    assertThat(performances.getFirst().getPerformanceCode()).isEqualTo("TPER01");
+                    assertThat(performances.getFirst().getPerformanceDate()).isEqualTo(LocalDate.of(2026, 12, 1));
+                });
+    }
+
+    @Test
+    void testFindByMinDate_NoResults() {
+        webTestClient.get()
+                .uri(TheaterPerformanceResource.PERFORMANCES + TheaterPerformanceResource.SEARCH + "?minDate=2027-01-01")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBodyList(TheaterPerformance.class)
+                .value(performances -> assertThat(performances).isEmpty());
+    }
+
+    @Test
+    void testFindByMinDate_AllPerformances() {
+        webTestClient.get()
+                .uri(TheaterPerformanceResource.PERFORMANCES + TheaterPerformanceResource.SEARCH + "?minDate=2026-01-01")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBodyList(TheaterPerformance.class)
+                .value(performances -> {
+                    assertThat(performances).hasSize(1);
+                    assertThat(performances.getFirst().getPerformanceCode()).isEqualTo("TPER01");
+                });
+    }
+}


### PR DESCRIPTION
## Summary

Adds the first Theater search endpoint for issue #1392.

Endpoint:

`GET /theater/performances/search?minDate=2026-09-01`

Behavior:

- Returns `Stream<TheaterPerformance>`.
- Filters performances with `performanceDate >= minDate`.
- Returns an empty stream when no performances match.
- Does not throw `NotFoundException` for empty search results.

## Architecture

The implementation follows the existing APAW search endpoint style:

Resource
→ Service
→ Persistence Port
→ MongoDB Persistence Adapter
→ MongoTemplate query

## Main changes

- Added `findByMinDate(LocalDate minDate)` to `TheaterPerformancePersistence`.
- Implemented the MongoDB query with `MongoTemplate` and `Criteria.where("performanceDate").gte(minDate)`.
- Added `TheaterPerformanceService`.
- Added `TheaterPerformanceResource`.
- Added service, functional, and persistence integration tests.

## Validation

Cursor validation reported:

- `mvn -q -DskipTests compile` passed.
- `mvn -q "-Dtest=*Theater*" test` passed.
- `mvn -q test` passed.

Manual pre-commit checks:

- `git diff --check` passed.
- Forbidden reverse relationship fields were not found:
  - `hallVenue`
  - `hallPerformances`
  - `artistPerformances`

## Scope control

- No Theater domain model changes.
- No new fields.
- No new relationships.
- No unrelated stories modified.
- No changes to `pom.xml`, GitHub Actions, Docker, or global configuration.

Related to #1392.
