### PR TITLE
Add theater hall capacity search #1394

### DIFF
--- a/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterHallPersistenceMongodb.java
+++ b/src/main/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterHallPersistenceMongodb.java
@@ -6,6 +6,9 @@ import es.upm.miw.apaw.domain.exceptions.NotFoundException;
 import es.upm.miw.apaw.domain.models.theater.TheaterHall;
 import es.upm.miw.apaw.domain.persistenceports.theater.TheaterHallPersistence;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.stream.Stream;
@@ -14,10 +17,13 @@ import java.util.stream.Stream;
 public class TheaterHallPersistenceMongodb implements TheaterHallPersistence {
 
     private final TheaterHallRepository theaterHallRepository;
+    private final MongoTemplate mongoTemplate;
 
     @Autowired
-    public TheaterHallPersistenceMongodb(TheaterHallRepository theaterHallRepository) {
+    public TheaterHallPersistenceMongodb(TheaterHallRepository theaterHallRepository,
+                                          MongoTemplate mongoTemplate) {
         this.theaterHallRepository = theaterHallRepository;
+        this.mongoTemplate = mongoTemplate;
     }
 
     @Override
@@ -49,5 +55,13 @@ public class TheaterHallPersistenceMongodb implements TheaterHallPersistence {
     @Override
     public boolean existsByHallCode(String hallCode) {
         return this.theaterHallRepository.findByHallCode(hallCode).isPresent();
+    }
+
+    @Override
+    public Stream<TheaterHall> findByMinCapacity(Integer minCapacity) {
+        Query query = new Query(Criteria.where("hallCapacity").gte(minCapacity));
+        return this.mongoTemplate.find(query, TheaterHallEntity.class)
+                .stream()
+                .map(TheaterHallEntity::toTheaterHall);
     }
 }

--- a/src/main/java/es/upm/miw/apaw/adapters/resources/theater/TheaterHallResource.java
+++ b/src/main/java/es/upm/miw/apaw/adapters/resources/theater/TheaterHallResource.java
@@ -4,11 +4,15 @@ import es.upm.miw.apaw.domain.models.theater.TheaterHall;
 import es.upm.miw.apaw.domain.services.theater.TheaterHallService;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.stream.Stream;
 
 @RestController
 @RequestMapping(TheaterHallResource.HALLS)
@@ -16,6 +20,7 @@ public class TheaterHallResource {
 
     public static final String HALLS = "/theater/halls";
     public static final String HALL_CODE = "/{hallCode}";
+    public static final String SEARCH = "/search";
 
     private final TheaterHallService theaterHallService;
 
@@ -27,5 +32,10 @@ public class TheaterHallResource {
     @PutMapping(HALL_CODE)
     public TheaterHall update(@PathVariable String hallCode, @Valid @RequestBody TheaterHall theaterHall) {
         return this.theaterHallService.update(hallCode, theaterHall);
+    }
+
+    @GetMapping(SEARCH)
+    public Stream<TheaterHall> findByMinCapacity(@RequestParam Integer minCapacity) {
+        return this.theaterHallService.findByMinCapacity(minCapacity);
     }
 }

--- a/src/main/java/es/upm/miw/apaw/domain/persistenceports/theater/TheaterHallPersistence.java
+++ b/src/main/java/es/upm/miw/apaw/domain/persistenceports/theater/TheaterHallPersistence.java
@@ -17,4 +17,6 @@ public interface TheaterHallPersistence {
     Stream<TheaterHall> readAll();
 
     boolean existsByHallCode(String hallCode);
+
+    Stream<TheaterHall> findByMinCapacity(Integer minCapacity);
 }

--- a/src/main/java/es/upm/miw/apaw/domain/services/theater/TheaterHallService.java
+++ b/src/main/java/es/upm/miw/apaw/domain/services/theater/TheaterHallService.java
@@ -5,6 +5,8 @@ import es.upm.miw.apaw.domain.persistenceports.theater.TheaterHallPersistence;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.stream.Stream;
+
 @Service
 public class TheaterHallService {
 
@@ -17,5 +19,9 @@ public class TheaterHallService {
 
     public TheaterHall update(String hallCode, TheaterHall theaterHall) {
         return this.theaterHallPersistence.update(hallCode, theaterHall);
+    }
+
+    public Stream<TheaterHall> findByMinCapacity(Integer minCapacity) {
+        return this.theaterHallPersistence.findByMinCapacity(minCapacity);
     }
 }

--- a/src/test/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterHallPersistenceMongodbIT.java
+++ b/src/test/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterHallPersistenceMongodbIT.java
@@ -89,4 +89,24 @@ class TheaterHallPersistenceMongodbIT extends BaseTheaterTests {
         assertThat(theaterHallPersistenceMongodb.existsByHallCode(halls[0].getHallCode())).isTrue();
         assertThat(theaterHallPersistenceMongodb.existsByHallCode("NONEXISTENT")).isFalse();
     }
+
+    @Test
+    void testFindByMinCapacity() {
+        var results = theaterHallPersistenceMongodb.findByMinCapacity(150).toList();
+        assertThat(results).hasSize(1);
+        assertThat(results.getFirst().getHallCode()).isEqualTo("THAL01");
+        assertThat(results.getFirst().getHallCapacity()).isEqualTo(300);
+    }
+
+    @Test
+    void testFindByMinCapacity_Boundary() {
+        var results = theaterHallPersistenceMongodb.findByMinCapacity(100).toList();
+        assertThat(results).hasSize(2);
+    }
+
+    @Test
+    void testFindByMinCapacity_NoResults() {
+        var results = theaterHallPersistenceMongodb.findByMinCapacity(400).toList();
+        assertThat(results).isEmpty();
+    }
 }

--- a/src/test/java/es/upm/miw/apaw/domain/services/theater/TheaterHallServiceTest.java
+++ b/src/test/java/es/upm/miw/apaw/domain/services/theater/TheaterHallServiceTest.java
@@ -14,6 +14,9 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.List;
+import java.util.stream.Stream;
+
 @SpringBootTest
 @ActiveProfiles("test")
 class TheaterHallServiceTest {
@@ -57,5 +60,36 @@ class TheaterHallServiceTest {
         assertThatThrownBy(() -> this.theaterHallService.update("NONEXISTENT", hall))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("NONEXISTENT");
+    }
+
+    @Test
+    void testFindByMinCapacity() {
+        TheaterHall hall = TheaterHall.builder()
+                .hallCode("THAL01")
+                .hallName("Theater Hall A")
+                .hallCapacity(300)
+                .hallAccessible(true)
+                .build();
+        BDDMockito.given(this.theaterHallPersistence.findByMinCapacity(Mockito.eq(150)))
+                .willReturn(Stream.of(hall));
+
+        Stream<TheaterHall> result = this.theaterHallService.findByMinCapacity(150);
+        List<TheaterHall> list = result.toList();
+
+        assertThat(list).hasSize(1);
+        assertThat(list.getFirst().getHallCode()).isEqualTo("THAL01");
+        assertThat(list.getFirst().getHallCapacity()).isEqualTo(300);
+        BDDMockito.then(this.theaterHallPersistence).should().findByMinCapacity(150);
+    }
+
+    @Test
+    void testFindByMinCapacity_NoResults() {
+        BDDMockito.given(this.theaterHallPersistence.findByMinCapacity(Mockito.any(Integer.class)))
+                .willReturn(Stream.empty());
+
+        Stream<TheaterHall> result = this.theaterHallService.findByMinCapacity(500);
+        List<TheaterHall> list = result.toList();
+
+        assertThat(list).isEmpty();
     }
 }

--- a/src/test/java/es/upm/miw/apaw/functionaltests/theater/TheaterHallResourceFT.java
+++ b/src/test/java/es/upm/miw/apaw/functionaltests/theater/TheaterHallResourceFT.java
@@ -11,6 +11,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -78,5 +80,39 @@ class TheaterHallResourceFT extends BaseTheaterTests {
                 .bodyValue(hall)
                 .exchange()
                 .expectStatus().isBadRequest();
+    }
+
+    @Test
+    void testFindByMinCapacity() {
+        webTestClient.get()
+                .uri(TheaterHallResource.HALLS + TheaterHallResource.SEARCH + "?minCapacity=150")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBodyList(TheaterHall.class)
+                .value((List<TheaterHall> results) -> {
+                    assertThat(results).hasSize(1);
+                    assertThat(results.getFirst().getHallCode()).isEqualTo("THAL01");
+                    assertThat(results.getFirst().getHallCapacity()).isEqualTo(300);
+                });
+    }
+
+    @Test
+    void testFindByMinCapacity_Boundary() {
+        webTestClient.get()
+                .uri(TheaterHallResource.HALLS + TheaterHallResource.SEARCH + "?minCapacity=100")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBodyList(TheaterHall.class)
+                .value((List<TheaterHall> results) -> assertThat(results).hasSize(2));
+    }
+
+    @Test
+    void testFindByMinCapacity_NoResults() {
+        webTestClient.get()
+                .uri(TheaterHallResource.HALLS + TheaterHallResource.SEARCH + "?minCapacity=400")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBodyList(TheaterHall.class)
+                .value((List<TheaterHall> results) -> assertThat(results).isEmpty());
     }
 }


### PR DESCRIPTION
## Summary

Adds the second Theater search endpoint for issue #1394.

Endpoint:

`GET /theater/halls/search?minCapacity=100`

Behavior:

- Returns `Stream<TheaterHall>`.
- Filters halls with `hallCapacity >= minCapacity`.
- Returns an empty stream when no halls match.
- Does not throw `NotFoundException` for empty search results.

## Architecture

The implementation follows the existing APAW search endpoint style:

Resource
→ Service
→ Persistence Port
→ MongoDB Persistence Adapter
→ MongoTemplate query

## Main changes

- Added `findByMinCapacity(Integer minCapacity)` to `TheaterHallPersistence`.
- Implemented the MongoDB query with `MongoTemplate` and `Criteria.where("hallCapacity").gte(minCapacity)`.
- Added `findByMinCapacity(Integer minCapacity)` to `TheaterHallService`.
- Added `GET /theater/halls/search?minCapacity=...` to `TheaterHallResource`.
- Added service, functional, and persistence integration tests.

## Validation

Cursor validation reported:

- `mvn -q -DskipTests compile` passed.
- `mvn -q "-Dtest=*Theater*" test` passed.
- `mvn -q test` passed.

Manual pre-commit checks:

- `git diff --check` passed.
- Forbidden reverse relationship fields were not found:
  - `hallVenue`
  - `hallPerformances`
  - `artistPerformances`

## Scope control

- No Theater domain model changes.
- No new fields.
- No new relationships.
- No unrelated stories modified.
- No changes to `pom.xml`, GitHub Actions, Docker, or global configuration.

Related to #1394.
