### PR TITLE
Fix theater hall capacity search tests #1394

### DIFF
--- a/src/test/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterHallPersistenceMongodbIT.java
+++ b/src/test/java/es/upm/miw/apaw/adapters/mongodb/theater/persistence/TheaterHallPersistenceMongodbIT.java
@@ -106,7 +106,7 @@ class TheaterHallPersistenceMongodbIT extends BaseTheaterTests {
 
     @Test
     void testFindByMinCapacity_NoResults() {
-        var results = theaterHallPersistenceMongodb.findByMinCapacity(400).toList();
+        var results = theaterHallPersistenceMongodb.findByMinCapacity(10000).toList();
         assertThat(results).isEmpty();
     }
 }

--- a/src/test/java/es/upm/miw/apaw/functionaltests/theater/TheaterHallResourceFT.java
+++ b/src/test/java/es/upm/miw/apaw/functionaltests/theater/TheaterHallResourceFT.java
@@ -90,9 +90,9 @@ class TheaterHallResourceFT extends BaseTheaterTests {
                 .expectStatus().isOk()
                 .expectBodyList(TheaterHall.class)
                 .value((List<TheaterHall> results) -> {
-                    assertThat(results).hasSize(1);
-                    assertThat(results.getFirst().getHallCode()).isEqualTo("THAL01");
-                    assertThat(results.getFirst().getHallCapacity()).isEqualTo(300);
+                    assertThat(results).isNotEmpty();
+                    assertThat(results).allSatisfy(hall ->
+                            assertThat(hall.getHallCapacity()).isGreaterThanOrEqualTo(150));
                 });
     }
 
@@ -103,13 +103,17 @@ class TheaterHallResourceFT extends BaseTheaterTests {
                 .exchange()
                 .expectStatus().isOk()
                 .expectBodyList(TheaterHall.class)
-                .value((List<TheaterHall> results) -> assertThat(results).hasSize(2));
+                .value((List<TheaterHall> results) -> {
+                    assertThat(results).isNotEmpty();
+                    assertThat(results).allSatisfy(hall ->
+                            assertThat(hall.getHallCapacity()).isGreaterThanOrEqualTo(100));
+                });
     }
 
     @Test
     void testFindByMinCapacity_NoResults() {
         webTestClient.get()
-                .uri(TheaterHallResource.HALLS + TheaterHallResource.SEARCH + "?minCapacity=400")
+                .uri(TheaterHallResource.HALLS + TheaterHallResource.SEARCH + "?minCapacity=10000")
                 .exchange()
                 .expectStatus().isOk()
                 .expectBodyList(TheaterHall.class)


### PR DESCRIPTION
## Summary

Fixes the develop CI failure after merging #1395 for issue #1394.

Failed develop Actions run:

https://github.com/miw-upm/apaw-practice/actions/runs/27085623779

## Root cause

`TheaterHallResourceFT.testFindByMinCapacity` asserted a fixed result size for `minCapacity=150`.

That assumption was too strict because the full CI environment loads global Theater seed data. In CI, the endpoint correctly returned multiple halls satisfying `hallCapacity >= 150`:

- HAL001 with capacity 500
- HAL002 with capacity 150
- THAL01 with capacity 300

The endpoint behavior was correct. The test assertion was environment-specific.

## Fix

- Replaced fixed-size and first-element assertions with semantic assertions:
  - result is not empty
  - every returned hall has `hallCapacity >= minCapacity`
- Changed no-results threshold from `400` to `10000` to avoid matching global seed data.
- Applied the no-results threshold fix to the persistence integration test as well.

## Scope control

- Test-only fix.
- No main code changed.
- No Theater domain model changes.
- No new fields.
- No new relationships.
- No unrelated stories modified.
- Forbidden reverse relationship fields remain absent:
  - `hallVenue`
  - `hallPerformances`
  - `artistPerformances`

## Validation

Cursor validation reported:

- `mvn -q -DskipTests compile` passed.
- `mvn -q "-Dtest=*TheaterHall*" test` passed.
- `mvn -q "-Dtest=*Theater*" test` passed.
- `mvn -q test` passed.

Related to #1394.
